### PR TITLE
fix: respect ironSkipEntranceAnimations in accessibleAnimation

### DIFF
--- a/Sources/IronCore/Theming/Tokens/IronAnimationTokens.swift
+++ b/Sources/IronCore/Theming/Tokens/IronAnimationTokens.swift
@@ -159,9 +159,13 @@ private struct AccessibleAnimationModifier<V: Equatable>: ViewModifier {
   let value: V
 
   func body(content: Content) -> some View {
-    content.animation(reduceMotion ? nil : animation, value: value)
+    content.animation(shouldSkipAnimation ? nil : animation, value: value)
   }
 
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @Environment(\.ironSkipEntranceAnimations) private var skipEntranceAnimations
 
+  private var shouldSkipAnimation: Bool {
+    reduceMotion || skipEntranceAnimations
+  }
 }


### PR DESCRIPTION
## Summary

- Update `AccessibleAnimationModifier` to also check `ironSkipEntranceAnimations` environment value
- Animations are now skipped when either `accessibilityReduceMotion` OR `ironSkipEntranceAnimations` is enabled

This ensures all components using `accessibleAnimation` properly respect both accessibility settings and the testing flag for deterministic snapshots.

Closes #13

## Test plan

- [ ] Verify animations are disabled when `accessibilityReduceMotion` is enabled
- [ ] Verify animations are disabled when `ironSkipEntranceAnimations` is set to `true`
- [ ] Run snapshot tests to confirm deterministic output

🤖 Generated with [Claude Code](https://claude.com/claude-code)