### PR TITLE
fix: respect Reduce Motion in animated components

### DIFF
--- a/Sources/IronComponents/Chip/IronChip.swift
+++ b/Sources/IronComponents/Chip/IronChip.swift
@@ -187,7 +187,7 @@ public struct IronChip<LeadingIcon: View>: View {
 
       if let onDismiss {
         Button {
-          withAnimation(reduceMotion ? nil : theme.animation.snappy) {
+          withAnimation(shouldAnimate ? theme.animation.snappy : nil) {
             onDismiss()
           }
           IronLogger.ui.debug("IronChip dismissed")
@@ -221,7 +221,7 @@ public struct IronChip<LeadingIcon: View>: View {
     .contentShape(Capsule())
     .onTapGesture {
       guard isSelectable else { return }
-      withAnimation(reduceMotion ? nil : theme.animation.bouncy) {
+      withAnimation(shouldAnimate ? theme.animation.bouncy : nil) {
         isSelected?.toggle()
       }
       IronLogger.ui.debug(
@@ -273,6 +273,7 @@ public struct IronChip<LeadingIcon: View>: View {
 
   @Environment(\.ironTheme) private var theme
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @Environment(\.ironSkipEntranceAnimations) private var skipEntranceAnimations
 
   @Binding private var isSelected: Bool?
   @State private var isPressed = false
@@ -288,6 +289,10 @@ public struct IronChip<LeadingIcon: View>: View {
 
   private var isSelectable: Bool {
     isSelected != nil
+  }
+
+  private var shouldAnimate: Bool {
+    !reduceMotion && !skipEntranceAnimations
   }
 
   private var textStyle: IronTextStyle {

--- a/Sources/IronComponents/Skeleton/IronSkeleton.swift
+++ b/Sources/IronComponents/Skeleton/IronSkeleton.swift
@@ -133,6 +133,10 @@ public struct IronSkeleton: View {
       .frame(width: gradientWidth)
       .offset(x: shimmerOffset * (width + gradientWidth) - gradientWidth)
       .onAppear {
+        guard shouldAnimate else {
+          shimmerOffset = 0.5 // Static position when animations disabled
+          return
+        }
         withAnimation(
           .linear(duration: 1.5)
             .repeatForever(autoreverses: false)

--- a/Sources/IronPrimitives/Toggle/IronToggle.swift
+++ b/Sources/IronPrimitives/Toggle/IronToggle.swift
@@ -155,6 +155,7 @@ public struct IronToggle<Label: View>: View {
   @Environment(\.ironTheme) private var theme
   @Environment(\.isEnabled) private var isEnabled
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @Environment(\.ironSkipEntranceAnimations) private var skipEntranceAnimations
 
   @Binding private var isOn: Bool
 
@@ -331,9 +332,13 @@ public struct IronToggle<Label: View>: View {
     }
   }
 
+  private var shouldAnimate: Bool {
+    !reduceMotion && !skipEntranceAnimations
+  }
+
   /// Toggles the state with animation and logging
   private func toggleWithAnimation() {
-    withAnimation(reduceMotion ? nil : theme.animation.bouncy) {
+    withAnimation(shouldAnimate ? theme.animation.bouncy : nil) {
       isOn.toggle()
     }
     IronLogger.ui.debug(


### PR DESCRIPTION
## Summary

- **IronSkeleton**: Gate shimmer animation on `shouldAnimate` to prevent continuous animations when disabled
- **IronChip**: Add `ironSkipEntranceAnimations` environment check alongside `reduceMotion`  
- **IronToggle**: Add `ironSkipEntranceAnimations` environment check alongside `reduceMotion`

All three components now properly respect both `accessibilityReduceMotion` and `ironSkipEntranceAnimations` flags, ensuring animations are disabled when users prefer reduced motion or during snapshot tests.

## Test plan

- [x] Build succeeds
- [ ] Animated components respect Reduce Motion accessibility setting
- [ ] Snapshot tests produce consistent results with entrance animations disabled

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)