### PR TITLE
fix: respect ironSkipEntranceAnimations in animated components

### DIFF
--- a/Sources/IronComponents/SegmentedControl/IronSegmentedControl.swift
+++ b/Sources/IronComponents/SegmentedControl/IronSegmentedControl.swift
@@ -89,14 +89,14 @@ public struct IronSegmentedControl<Option: Hashable, Label: View>: View {
           .frame(width: segmentWidth - indicatorPadding * 2)
           .padding(indicatorPadding)
           .offset(x: selectedIndex * segmentWidth)
-          .animation(theme.animation.bouncy, value: selection)
+          .animation(shouldAnimate ? theme.animation.bouncy : nil, value: selection)
           .accessibilityHidden(true)
 
         // Segments
         HStack(spacing: 0) {
           ForEach(Array(options.enumerated()), id: \.offset) { index, option in
             Button {
-              withAnimation(theme.animation.bouncy) {
+              withAnimation(shouldAnimate ? theme.animation.bouncy : nil) {
                 selection = option
               }
               IronLogger.ui.debug(
@@ -127,6 +127,8 @@ public struct IronSegmentedControl<Option: Hashable, Label: View>: View {
   // MARK: Private
 
   @Environment(\.ironTheme) private var theme
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @Environment(\.ironSkipEntranceAnimations) private var skipEntranceAnimations
   @Namespace private var namespace
 
   @Binding private var selection: Option
@@ -174,6 +176,10 @@ public struct IronSegmentedControl<Option: Hashable, Label: View>: View {
     case .medium: theme.typography.labelMedium
     case .large: theme.typography.labelLarge
     }
+  }
+
+  private var shouldAnimate: Bool {
+    !reduceMotion && !skipEntranceAnimations
   }
 }
 

--- a/Sources/IronPrimitives/Alert/IronAlert.swift
+++ b/Sources/IronPrimitives/Alert/IronAlert.swift
@@ -308,7 +308,7 @@ public struct IronAlert<Icon: View, Actions: View>: View {
       // Dismiss button
       if let onDismiss {
         Button {
-          withAnimation(reduceMotion ? nil : theme.animation.snappy) {
+          withAnimation(shouldAnimate ? theme.animation.snappy : nil) {
             onDismiss()
           }
           IronLogger.ui.debug("IronAlert dismissed", metadata: ["variant": .string("\(variant)")])
@@ -354,6 +354,7 @@ public struct IronAlert<Icon: View, Actions: View>: View {
 
   @Environment(\.ironTheme) private var theme
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @Environment(\.ironSkipEntranceAnimations) private var skipEntranceAnimations
 
   private let title: LocalizedStringKey?
   private let message: LocalizedStringKey
@@ -430,6 +431,10 @@ public struct IronAlert<Icon: View, Actions: View>: View {
       return Text(message)
     }
     return Text(accessibilityMessage)
+  }
+
+  private var shouldAnimate: Bool {
+    !reduceMotion && !skipEntranceAnimations
   }
 }
 

--- a/Sources/IronPrimitives/Checkbox/IronCheckbox.swift
+++ b/Sources/IronPrimitives/Checkbox/IronCheckbox.swift
@@ -135,7 +135,7 @@ public struct IronCheckbox<Label: View>: View {
 
   public var body: some View {
     let button = Button {
-      withAnimation(reduceMotion ? nil : theme.animation.bouncy) {
+      withAnimation(shouldAnimate ? theme.animation.bouncy : nil) {
         isChecked.toggle()
       }
       IronLogger.ui.debug(
@@ -184,6 +184,7 @@ public struct IronCheckbox<Label: View>: View {
   @Environment(\.ironTheme) private var theme
   @Environment(\.isEnabled) private var isEnabled
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @Environment(\.ironSkipEntranceAnimations) private var skipEntranceAnimations
 
   @Binding private var isChecked: Bool
 
@@ -280,6 +281,10 @@ public struct IronCheckbox<Label: View>: View {
     case .error: return theme.colors.error
     case .custom(let customColor): return customColor
     }
+  }
+
+  private var shouldAnimate: Bool {
+    !reduceMotion && !skipEntranceAnimations
   }
 }
 

--- a/Sources/IronPrimitives/Radio/IronRadio.swift
+++ b/Sources/IronPrimitives/Radio/IronRadio.swift
@@ -119,7 +119,7 @@ public struct IronRadio<Value: Hashable, Label: View>: View {
 
   public var body: some View {
     Button {
-      withAnimation(reduceMotion ? nil : theme.animation.bouncy) {
+      withAnimation(shouldAnimate ? theme.animation.bouncy : nil) {
         selection = value
       }
       IronLogger.ui.debug(
@@ -148,6 +148,7 @@ public struct IronRadio<Value: Hashable, Label: View>: View {
   @Environment(\.ironTheme) private var theme
   @Environment(\.isEnabled) private var isEnabled
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @Environment(\.ironSkipEntranceAnimations) private var skipEntranceAnimations
 
   @Binding private var selection: Value
 
@@ -235,6 +236,10 @@ public struct IronRadio<Value: Hashable, Label: View>: View {
     case .error: return theme.colors.error
     case .custom(let customColor): return customColor
     }
+  }
+
+  private var shouldAnimate: Bool {
+    !reduceMotion && !skipEntranceAnimations
   }
 }
 


### PR DESCRIPTION
## Summary

- Update IronRadio, IronCheckbox, IronAlert, and IronSegmentedControl to honor the `ironSkipEntranceAnimations` environment value
- Each component now reads `@Environment(\.ironSkipEntranceAnimations)` and uses a `shouldAnimate` computed property
- Fixes inconsistent behavior where some components only checked `reduceMotion` but not `skipEntranceAnimations`

## Test plan

- [x] Build passes
- [x] Components respect `ironSkipEntranceAnimations` environment value
- [x] Pattern matches existing components (IronSpinner, IronSkeleton, IronToggle, etc.)

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)