### PR TITLE
fix: include variant and content in IronAlert accessibility label

### DIFF
--- a/Sources/IronPrimitives/Alert/IronAlert.swift
+++ b/Sources/IronPrimitives/Alert/IronAlert.swift
@@ -282,7 +282,7 @@ public struct IronAlert<Icon: View, Actions: View>: View {
   // MARK: Public
 
   public var body: some View {
-    let alertView = HStack(alignment: .top, spacing: theme.spacing.sm) {
+    HStack(alignment: .top, spacing: theme.spacing.sm) {
       // Icon
       iconView
         .padding(.top, 2)
@@ -340,14 +340,7 @@ public struct IronAlert<Icon: View, Actions: View>: View {
         .strokeBorder(borderColor, lineWidth: 1)
     }
     .accessibilityElement(children: .combine)
-    .accessibilityLabel(accessibilityPrimaryLabel)
-    .accessibilityValue(accessibilitySecondaryValue)
-
-    if title != nil {
-      alertView.accessibilityHint(Text(accessibilityMessage))
-    } else {
-      alertView
-    }
+    .accessibilityLabel(accessibilityLabel)
   }
 
   // MARK: Private
@@ -410,7 +403,7 @@ public struct IronAlert<Icon: View, Actions: View>: View {
     foregroundColor.opacity(0.25)
   }
 
-  private var accessibilityMessage: String {
+  private var variantAccessibilityLabel: String {
     switch variant {
     case .info: "Information"
     case .success: "Success"
@@ -419,18 +412,15 @@ public struct IronAlert<Icon: View, Actions: View>: View {
     }
   }
 
-  private var accessibilityPrimaryLabel: Text {
+  /// Comprehensive accessibility label that announces variant, title, and message.
+  ///
+  /// Format: "Warning: Title. Message" or "Information: Message"
+  private var accessibilityLabel: Text {
     if let title {
-      return Text(title)
+      Text("\(variantAccessibilityLabel): \(Text(title)). \(Text(message))")
+    } else {
+      Text("\(variantAccessibilityLabel): \(Text(message))")
     }
-    return Text(message)
-  }
-
-  private var accessibilitySecondaryValue: Text {
-    if title != nil {
-      return Text(message)
-    }
-    return Text(accessibilityMessage)
   }
 
   private var shouldAnimate: Bool {


### PR DESCRIPTION
## Summary

- Consolidate IronAlert accessibility into a single comprehensive label
- Screen readers now announce alerts with variant type and content together
- Format: "Warning: Title. Message" or "Information: Message"

## Changes

- Replaced separate `accessibilityLabel`, `accessibilityValue`, and `accessibilityHint` with a single comprehensive `accessibilityLabel`
- Variant type is announced first for immediate context (e.g., "Warning:", "Error:")
- Title and message are included in the same announcement

## Test plan

- [x] Build passes
- [x] All IronAlert unit tests pass
- [ ] Manual VoiceOver testing to verify screen reader experience

Fixes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)