### PR TITLE
fix: enforce 44pt minimum touch targets on all interactive controls

### DIFF
--- a/Sources/IronComponents/Menu/IronMenu.swift
+++ b/Sources/IronComponents/Menu/IronMenu.swift
@@ -144,13 +144,14 @@ public struct IronMenuLabel: View {
     }
     .padding(.horizontal, theme.spacing.md)
     .padding(.vertical, theme.spacing.sm)
-    .frame(minHeight: minTouchTarget)
+    .frame(minWidth: minTouchTarget, minHeight: minTouchTarget)
     .background(theme.colors.surface)
     .clipShape(RoundedRectangle(cornerRadius: theme.radii.md))
     .overlay {
       RoundedRectangle(cornerRadius: theme.radii.md)
         .strokeBorder(theme.colors.onSurface.opacity(0.3), lineWidth: 1)
     }
+    .contentShape(RoundedRectangle(cornerRadius: theme.radii.md))
     .accessibilityElement(children: .combine)
     .accessibilityHint("Opens menu")
     .accessibilityAddTraits(.isButton)

--- a/Sources/IronPrimitives/Alert/IronAlert.swift
+++ b/Sources/IronPrimitives/Alert/IronAlert.swift
@@ -316,7 +316,8 @@ public struct IronAlert<Icon: View, Actions: View>: View {
           IronIcon(systemName: "xmark", size: .xSmall, color: .secondary)
             .frame(width: 20, height: 20)
             .background(theme.colors.onSurface.opacity(0.08), in: Circle())
-            .frame(width: minTouchTarget, height: minTouchTarget)
+            .frame(minWidth: minTouchTarget, minHeight: minTouchTarget)
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .accessibilityLabel("Dismiss")

--- a/Sources/IronPrimitives/Radio/IronRadio.swift
+++ b/Sources/IronPrimitives/Radio/IronRadio.swift
@@ -133,7 +133,8 @@ public struct IronRadio<Value: Hashable, Label: View>: View {
         label
           .opacity(isEnabled ? 1.0 : 0.5)
       }
-      .frame(minHeight: minTouchTarget)
+      .frame(minWidth: minTouchTarget, minHeight: minTouchTarget)
+      .contentShape(Rectangle())
     }
     .buttonStyle(.plain)
     .disabled(!isEnabled)


### PR DESCRIPTION
## Summary
- Add `minWidth: 44pt` and `contentShape` to `IronRadio` to ensure the full button area is tappable
- Add `minWidth: 44pt` and `contentShape` to `IronMenuLabel` for proper menu trigger hit area
- Update `IronAlert` dismiss button to use `minWidth`/`minHeight` with `contentShape` to ensure the full 44pt area is tappable

## Test plan
- [x] Build succeeds
- [x] Unit tests pass (237 tests)
- [ ] Manual testing of touch targets on iOS device/simulator

Fixes #14