### PR TITLE
docs: update ADRs and add Component API Design

### DIFF
--- a/adrs/0002-theming-approach.md
+++ b/adrs/0002-theming-approach.md
@@ -25,10 +25,9 @@ Global Tokens (Raw Values)
     |
     v
 Semantic Tokens (Meaning-based)
-    |
-    v
-Component Tokens (Component-specific)
 ```
+
+> **Note:** A third tier (Component Tokens) was considered but deferred. Components currently access semantic tokens directly via `theme.colors.primary`, `theme.typography.bodyLarge`, etc. Component-specific token protocols may be added if per-component customization demand arises, but the current two-tier system provides sufficient flexibility while keeping theme creation simple.
 
 ### Core Protocols
 

--- a/adrs/0003-visual-identity.md
+++ b/adrs/0003-visual-identity.md
@@ -6,12 +6,13 @@ Accepted
 
 ## Context
 
-IronUI needs a distinctive visual identity that sets it apart from generic component libraries while remaining unopinionated enough for broad adoption. We want to be:
+IronUI needs a distinctive visual identity that sets it apart from generic component libraries. We want to be:
 
-1. Beautiful and modern
-2. Cutting-edge in motion design
-3. Delightful to use
-4. Accessible
+1. **Modern and stylish** - A bold, contemporary aesthetic
+2. **Opinionated by default** - Ships with a distinctive, polished theme out of the box
+3. **Themable and customizable** - Consumers can override tokens to match their brand
+4. **Cutting-edge in motion design** - Delightful animations that respect accessibility
+5. **Accessible** - Never sacrificing usability for aesthetics
 
 ## Decision
 
@@ -78,16 +79,6 @@ Ship an opinionated, stylish default theme that embodies these principles:
 
 - Users can still create neutral themes
 - Philosophy guides decisions but doesn't mandate specific implementations
-
-## Alternatives Considered
-
-### Minimal/System-like Default
-
-Ship with neutral, system-like defaults. Less distinctive, harder to stand out.
-
-### No Default Theme
-
-Require users to provide all theming. Too much friction for adoption.
 
 ## References
 

--- a/adrs/0006-component-api-design.md
+++ b/adrs/0006-component-api-design.md
@@ -1,0 +1,163 @@
+# ADR-0006: Component API Design
+
+## Status
+
+Accepted
+
+## Context
+
+As IronUI grows, consistent API design across components becomes critical for:
+
+1. Developer experience and discoverability
+2. Reducing cognitive load when learning new components
+3. Maintaining a cohesive library feel
+4. Preventing breaking changes from inconsistent patterns
+
+## Decision
+
+Establish the following API design conventions for all IronUI components:
+
+### 1. Naming Conventions
+
+**Boolean properties** use `is` prefix:
+```swift
+isDisabled, isSelected, isChecked, isOn, isRequired, isFullWidth
+```
+
+**Action callbacks** use `on` prefix:
+```swift
+onTap, onDismiss, onChange, onSubmit
+```
+
+**Content builders** use descriptive names:
+```swift
+label, content, header, footer, leading, trailing
+```
+
+### 2. Controlled Components
+
+All interactive components use `Binding<T>` (controlled pattern):
+
+```swift
+// Correct: Controlled via Binding
+IronToggle(isOn: $isEnabled)
+IronTextField(text: $email)
+
+// Not supported: Uncontrolled with initial value
+IronToggle(initialValue: true)  // ❌
+```
+
+**Rationale:** Controlled components provide predictable state, easier testing, and align with SwiftUI conventions.
+
+### 3. Configuration vs Composition
+
+**Use configuration (parameters)** for:
+- Variants and sizes (closed set of options)
+- Boolean flags
+- Simple string content
+
+**Use composition (`@ViewBuilder`)** for:
+- Complex or custom content
+- When consumers need full control over child views
+
+**Provide both when practical:**
+```swift
+// Configuration (convenience)
+IronButton("Submit", variant: .filled) { }
+
+// Composition (flexibility)
+IronButton(variant: .filled) {
+    // action
+} label: {
+    HStack {
+        Image(systemName: "paperplane")
+        Text("Submit")
+    }
+}
+```
+
+### 4. Closed Enums for Variants
+
+Variant and size types are **closed enums**, not protocols:
+
+```swift
+public enum IronButtonVariant: Sendable, CaseIterable {
+    case filled, outlined, ghost, elevated
+}
+
+public enum IronButtonSize: Sendable, CaseIterable {
+    case small, medium, large
+}
+```
+
+**Rationale:**
+- Ensures exhaustive switch statements
+- Prevents untested custom variants
+- New variants are added via library updates or feature requests
+- Keeps the design system cohesive
+
+### 5. Optional Callbacks
+
+Use optional closures with `nil` default, not empty closures:
+
+```swift
+// Correct
+public init(onDismiss: (() -> Void)? = nil)
+
+// Avoid
+public init(onDismiss: @escaping () -> Void = {})
+```
+
+**Rationale:** Allows components to conditionally render UI (e.g., dismiss button) based on callback presence.
+
+### 6. Initializer Parameter Order
+
+Follow this order for consistency:
+
+1. Content/title (first, often unlabeled)
+2. Binding (if applicable)
+3. Variant/style
+4. Size
+5. Color
+6. Boolean modifiers (isDisabled, isRequired, etc.)
+7. Callbacks (onTap, onDismiss)
+8. ViewBuilder content/label (trailing)
+
+```swift
+public init(
+    _ title: LocalizedStringKey,           // 1. Content
+    variant: IronButtonVariant = .filled,  // 3. Variant
+    size: IronButtonSize = .medium,        // 4. Size
+    isFullWidth: Bool = false,             // 6. Boolean
+    action: @escaping () -> Void           // 7. Callback
+)
+```
+
+### 7. Localization
+
+All user-facing strings accept `LocalizedStringKey`:
+
+```swift
+public init(_ title: LocalizedStringKey)
+public init(_ title: String)  // Convenience, converts internally
+```
+
+## Consequences
+
+### Positive
+
+- Predictable, learnable API across all components
+- Easier code review (deviations from conventions are obvious)
+- Better autocomplete experience
+- Reduced documentation burden (patterns are consistent)
+
+### Negative
+
+- Some flexibility sacrificed (no custom variants)
+- Requires discipline to maintain consistency
+- Existing components may need updates to conform
+
+## References
+
+- [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/)
+- [SwiftUI Component Patterns](https://developer.apple.com/documentation/swiftui)


### PR DESCRIPTION
## Summary

- **ADR-0002**: Clarify that component tokens tier is deferred (two-tier system is sufficient)
- **ADR-0003**: Reword context to emphasize: modern, stylish, opinionated, themable design philosophy
- **ADR-0006**: New ADR for Component API Design conventions

## ADR-0006 Highlights

Establishes conventions for:
- Boolean props use `is` prefix (`isDisabled`, `isSelected`)
- Action callbacks use `on` prefix (`onTap`, `onDismiss`)
- All interactive components use controlled pattern (`Binding<T>`)
- Closed enums for variants/sizes (not extensible by consumers)
- Consistent initializer parameter ordering
- LocalizedStringKey for all user-facing strings

## Test plan

- [x] ADR files are valid markdown
- [x] No code changes, documentation only