### PR TITLE
chore: use previewable state in previews

### DIFF
--- a/Sources/IronComponents/Chip/IronChip.swift
+++ b/Sources/IronComponents/Chip/IronChip.swift
@@ -454,24 +454,18 @@ public enum IronChipSize: Sendable, CaseIterable {
 }
 
 #Preview("IronChip - Dismissible") {
-  struct Demo: View {
-    @State private var tags = ["Swift", "SwiftUI", "iOS", "macOS"]
+  @Previewable @State var tags = ["Swift", "SwiftUI", "iOS", "macOS"]
 
-    var body: some View {
-      HStack(spacing: 8) {
-        ForEach(tags, id: \.self) { tag in
-          IronChip(tag) {
-            withAnimation {
-              tags.removeAll { $0 == tag }
-            }
-          }
+  return HStack(spacing: 8) {
+    ForEach(tags, id: \.self) { tag in
+      IronChip(tag) {
+        withAnimation {
+          tags.removeAll { $0 == tag }
         }
       }
-      .padding()
     }
   }
-
-  return Demo()
+  .padding()
 }
 
 #Preview("IronChip - Selectable") {
@@ -488,36 +482,31 @@ public enum IronChipSize: Sendable, CaseIterable {
 }
 
 #Preview("IronChip - Filter Example") {
-  struct Demo: View {
-    @State private var filters: Set<String> = ["Active"]
+  @Previewable @State var filters: Set<String> = ["Active"]
 
-    let allFilters = ["All", "Active", "Completed", "Archived"]
+  let allFilters = ["All", "Active", "Completed", "Archived"]
 
-    var body: some View {
-      VStack(alignment: .leading, spacing: 16) {
-        IronText("Filters", style: .labelLarge, color: .primary)
+  return VStack(alignment: .leading, spacing: 16) {
+    IronText("Filters", style: .labelLarge, color: .primary)
 
-        HStack(spacing: 8) {
-          ForEach(allFilters, id: \.self) { filter in
-            IronChip(
-              filter,
-              isSelected: Binding(
-                get: { filters.contains(filter) },
-                set: { isSelected in
-                  if isSelected {
-                    filters.insert(filter)
-                  } else {
-                    filters.remove(filter)
-                  }
-                },
-              ),
-            )
-          }
-        }
+    HStack(spacing: 8) {
+      ForEach(allFilters, id: \.self) { filter in
+        IronChip(
+          filter,
+          isSelected: Binding(
+            get: { filters.contains(filter) },
+            set: { isSelected in
+              if isSelected {
+                filters.insert(filter)
+              } else {
+                filters.remove(filter)
+              }
+            },
+          ),
+        )
       }
-      .padding()
     }
   }
+  .padding()
 
-  return Demo()
 }

--- a/Sources/IronComponents/Menu/IronMenu.swift
+++ b/Sources/IronComponents/Menu/IronMenu.swift
@@ -443,20 +443,14 @@ public struct IronMenuPicker<Option: Hashable, Label: View>: View {
 }
 
 #Preview("IronMenuPicker") {
-  struct Demo: View {
-    enum SortOption: String, CaseIterable {
-      case name, date, size
-    }
-
-    @State private var sortBy = SortOption.name
-
-    var body: some View {
-      IronMenuPicker("Sort by: \(sortBy.rawValue.capitalized)", selection: $sortBy, options: SortOption.allCases) { option in
-        Text(option.rawValue.capitalized)
-      }
-      .padding()
-    }
+  enum SortOption: String, CaseIterable {
+    case name, date, size
   }
 
-  return Demo()
+  @Previewable @State var sortBy = SortOption.name
+
+  return IronMenuPicker("Sort by: \(sortBy.rawValue.capitalized)", selection: $sortBy, options: SortOption.allCases) { option in
+    Text(option.rawValue.capitalized)
+  }
+  .padding()
 }

--- a/Sources/IronComponents/SegmentedControl/IronSegmentedControl.swift
+++ b/Sources/IronComponents/SegmentedControl/IronSegmentedControl.swift
@@ -241,32 +241,26 @@ private enum PreviewTab: String, CaseIterable, CustomStringConvertible {
 }
 
 #Preview("IronSegmentedControl - Custom Labels") {
-  struct Demo: View {
-    @State private var selection = PreviewTab.posts
+  @Previewable @State var selection = PreviewTab.posts
 
-    var body: some View {
-      IronSegmentedControl(
-        selection: $selection,
-        options: PreviewTab.allCases,
-      ) { tab in
-        HStack(spacing: 4) {
-          Image(systemName: iconName(for: tab))
-          Text(tab.rawValue.capitalized)
-        }
-      }
-      .padding()
-    }
-
-    func iconName(for tab: PreviewTab) -> String {
-      switch tab {
-      case .posts: "doc.text"
-      case .photos: "photo"
-      case .videos: "video"
-      }
+  func iconName(for tab: PreviewTab) -> String {
+    switch tab {
+    case .posts: "doc.text"
+    case .photos: "photo"
+    case .videos: "video"
     }
   }
 
-  return Demo()
+  return IronSegmentedControl(
+    selection: $selection,
+    options: PreviewTab.allCases,
+  ) { tab in
+    HStack(spacing: 4) {
+      Image(systemName: iconName(for: tab))
+      Text(tab.rawValue.capitalized)
+    }
+  }
+  .padding()
 }
 
 #Preview("IronSegmentedControl - Sizes") {
@@ -304,64 +298,52 @@ private enum PreviewTab: String, CaseIterable, CustomStringConvertible {
 }
 
 #Preview("IronSegmentedControl - Two Options") {
-  struct Demo: View {
-    enum Mode: String, CaseIterable, CustomStringConvertible {
-      case list, grid
+  enum Mode: String, CaseIterable, CustomStringConvertible {
+    case list, grid
 
-      var description: String {
-        rawValue.capitalized
-      }
-    }
-
-    @State private var mode = Mode.list
-
-    var body: some View {
-      IronSegmentedControl(
-        selection: $mode,
-        options: Mode.allCases,
-      ) { mode in
-        HStack(spacing: 4) {
-          Image(systemName: mode == .list ? "list.bullet" : "square.grid.2x2")
-          Text(mode.rawValue.capitalized)
-        }
-      }
-      .frame(width: 200)
-      .padding()
+    var description: String {
+      rawValue.capitalized
     }
   }
 
-  return Demo()
+  @Previewable @State var mode = Mode.list
+
+  return IronSegmentedControl(
+    selection: $mode,
+    options: Mode.allCases,
+  ) { mode in
+    HStack(spacing: 4) {
+      Image(systemName: mode == .list ? "list.bullet" : "square.grid.2x2")
+      Text(mode.rawValue.capitalized)
+    }
+  }
+  .frame(width: 200)
+  .padding()
 }
 
 #if os(iOS)
 #Preview("IronSegmentedControl - In Context") {
-  struct Demo: View {
-    @State private var selection = PreviewTab.posts
+  @Previewable @State var selection = PreviewTab.posts
 
-    var body: some View {
-      VStack(spacing: 0) {
-        IronSegmentedControl(
-          selection: $selection,
-          options: PreviewTab.allCases,
-        )
-        .padding()
+  return VStack(spacing: 0) {
+    IronSegmentedControl(
+      selection: $selection,
+      options: PreviewTab.allCases,
+    )
+    .padding()
 
-        Divider()
+    Divider()
 
-        TabView(selection: $selection) {
-          ForEach(PreviewTab.allCases, id: \.self) { tab in
-            VStack {
-              IronText("\(tab.rawValue.capitalized) Content", style: .titleMedium, color: .primary)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .tag(tab)
-          }
+    TabView(selection: $selection) {
+      ForEach(PreviewTab.allCases, id: \.self) { tab in
+        VStack {
+          IronText("\(tab.rawValue.capitalized) Content", style: .titleMedium, color: .primary)
         }
-        .tabViewStyle(.page(indexDisplayMode: .never))
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .tag(tab)
       }
     }
+    .tabViewStyle(.page(indexDisplayMode: .never))
   }
-
-  return Demo()
 }
 #endif

--- a/Sources/IronPrimitives/Alert/IronAlert.swift
+++ b/Sources/IronPrimitives/Alert/IronAlert.swift
@@ -466,56 +466,50 @@ public enum IronAlertVariant: Sendable, CaseIterable {
 }
 
 #Preview("IronAlert - Dismissible") {
-  struct Demo: View {
-    @State private var showInfo = true
-    @State private var showSuccess = true
-    @State private var showWarning = true
-    @State private var showError = true
+  @Previewable @State var showInfo = true
+  @Previewable @State var showSuccess = true
+  @Previewable @State var showWarning = true
+  @Previewable @State var showError = true
 
-    var body: some View {
-      VStack(spacing: 16) {
-        if showInfo {
-          IronAlert("Tap the X to dismiss", variant: .info, onDismiss: {
-            showInfo = false
-          })
-        }
+  return VStack(spacing: 16) {
+    if showInfo {
+      IronAlert("Tap the X to dismiss", variant: .info, onDismiss: {
+        showInfo = false
+      })
+    }
 
-        if showSuccess {
-          IronAlert("Saved", message: "Your profile has been updated", variant: .success, onDismiss: {
-            showSuccess = false
-          })
-        }
+    if showSuccess {
+      IronAlert("Saved", message: "Your profile has been updated", variant: .success, onDismiss: {
+        showSuccess = false
+      })
+    }
 
-        if showWarning {
-          IronAlert("Warning", message: "This action cannot be undone", variant: .warning, onDismiss: {
-            showWarning = false
-          })
-        }
+    if showWarning {
+      IronAlert("Warning", message: "This action cannot be undone", variant: .warning, onDismiss: {
+        showWarning = false
+      })
+    }
 
-        if showError {
-          IronAlert("Error", message: "Failed to load data", variant: .error, onDismiss: {
-            showError = false
-          })
-        }
+    if showError {
+      IronAlert("Error", message: "Failed to load data", variant: .error, onDismiss: {
+        showError = false
+      })
+    }
 
-        if !showInfo, !showSuccess, !showWarning, !showError {
-          Button("Reset All") {
-            showInfo = true
-            showSuccess = true
-            showWarning = true
-            showError = true
-          }
-        }
+    if !showInfo, !showSuccess, !showWarning, !showError {
+      Button("Reset All") {
+        showInfo = true
+        showSuccess = true
+        showWarning = true
+        showError = true
       }
-      .padding()
-      .animation(.default, value: showInfo)
-      .animation(.default, value: showSuccess)
-      .animation(.default, value: showWarning)
-      .animation(.default, value: showError)
     }
   }
-
-  return Demo()
+  .padding()
+  .animation(.default, value: showInfo)
+  .animation(.default, value: showSuccess)
+  .animation(.default, value: showWarning)
+  .animation(.default, value: showError)
 }
 
 #Preview("IronAlert - With Actions") {

--- a/Sources/IronPrimitives/Checkbox/IronCheckbox.swift
+++ b/Sources/IronPrimitives/Checkbox/IronCheckbox.swift
@@ -321,126 +321,96 @@ public enum IronCheckboxColor: Sendable {
 // MARK: - Previews
 
 #Preview("IronCheckbox - Basic") {
-  struct Demo: View {
-    @State private var checked1 = false
-    @State private var checked2 = true
+  @Previewable @State var checked1 = false
+  @Previewable @State var checked2 = true
 
-    var body: some View {
-      VStack(spacing: 24) {
-        IronCheckbox(isChecked: $checked1)
-        IronCheckbox(isChecked: $checked2)
-      }
-      .padding()
-    }
+  return VStack(spacing: 24) {
+    IronCheckbox(isChecked: $checked1)
+    IronCheckbox(isChecked: $checked2)
   }
-
-  return Demo()
+  .padding()
 }
 
 #Preview("IronCheckbox - With Labels") {
-  struct Demo: View {
-    @State private var terms = false
-    @State private var privacy = false
-    @State private var newsletter = true
+  @Previewable @State var terms = false
+  @Previewable @State var privacy = false
+  @Previewable @State var newsletter = true
 
-    var body: some View {
-      VStack(alignment: .leading, spacing: 16) {
-        IronCheckbox("Accept Terms of Service", isChecked: $terms)
-        IronCheckbox("Accept Privacy Policy", isChecked: $privacy)
-        IronCheckbox("Subscribe to Newsletter", isChecked: $newsletter)
-      }
-      .padding()
-    }
+  return VStack(alignment: .leading, spacing: 16) {
+    IronCheckbox("Accept Terms of Service", isChecked: $terms)
+    IronCheckbox("Accept Privacy Policy", isChecked: $privacy)
+    IronCheckbox("Subscribe to Newsletter", isChecked: $newsletter)
   }
-
-  return Demo()
+  .padding()
 }
 
 #Preview("IronCheckbox - Custom Labels") {
-  struct Demo: View {
-    @State private var email = true
-    @State private var push = false
-    @State private var sms = false
+  @Previewable @State var email = true
+  @Previewable @State var push = false
+  @Previewable @State var sms = false
 
-    var body: some View {
-      VStack(alignment: .leading, spacing: 16) {
-        IronCheckbox(isChecked: $email) {
-          VStack(alignment: .leading) {
-            Text("Email Notifications")
-              .fontWeight(.medium)
-            Text("Receive updates via email")
-              .font(.caption)
-              .foregroundStyle(.secondary)
-          }
-        }
-
-        IronCheckbox(isChecked: $push) {
-          VStack(alignment: .leading) {
-            Text("Push Notifications")
-              .fontWeight(.medium)
-            Text("Get instant alerts on your device")
-              .font(.caption)
-              .foregroundStyle(.secondary)
-          }
-        }
-
-        IronCheckbox(isChecked: $sms) {
-          VStack(alignment: .leading) {
-            Text("SMS Notifications")
-              .fontWeight(.medium)
-            Text("Receive text message alerts")
-              .font(.caption)
-              .foregroundStyle(.secondary)
-          }
-        }
+  return VStack(alignment: .leading, spacing: 16) {
+    IronCheckbox(isChecked: $email) {
+      VStack(alignment: .leading) {
+        Text("Email Notifications")
+          .fontWeight(.medium)
+        Text("Receive updates via email")
+          .font(.caption)
+          .foregroundStyle(.secondary)
       }
-      .padding()
+    }
+
+    IronCheckbox(isChecked: $push) {
+      VStack(alignment: .leading) {
+        Text("Push Notifications")
+          .fontWeight(.medium)
+        Text("Get instant alerts on your device")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      }
+    }
+
+    IronCheckbox(isChecked: $sms) {
+      VStack(alignment: .leading) {
+        Text("SMS Notifications")
+          .fontWeight(.medium)
+        Text("Receive text message alerts")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      }
     }
   }
-
-  return Demo()
+  .padding()
 }
 
 #Preview("IronCheckbox - Sizes") {
-  struct Demo: View {
-    @State private var small = true
-    @State private var medium = true
-    @State private var large = true
+  @Previewable @State var small = true
+  @Previewable @State var medium = true
+  @Previewable @State var large = true
 
-    var body: some View {
-      VStack(alignment: .leading, spacing: 24) {
-        IronCheckbox("Small", isChecked: $small, size: .small)
-        IronCheckbox("Medium", isChecked: $medium, size: .medium)
-        IronCheckbox("Large", isChecked: $large, size: .large)
-      }
-      .padding()
-    }
+  return VStack(alignment: .leading, spacing: 24) {
+    IronCheckbox("Small", isChecked: $small, size: .small)
+    IronCheckbox("Medium", isChecked: $medium, size: .medium)
+    IronCheckbox("Large", isChecked: $large, size: .large)
   }
-
-  return Demo()
+  .padding()
 }
 
 #Preview("IronCheckbox - Colors") {
-  struct Demo: View {
-    @State private var primary = true
-    @State private var success = true
-    @State private var warning = true
-    @State private var error = true
-    @State private var custom = true
+  @Previewable @State var primary = true
+  @Previewable @State var success = true
+  @Previewable @State var warning = true
+  @Previewable @State var error = true
+  @Previewable @State var custom = true
 
-    var body: some View {
-      VStack(alignment: .leading, spacing: 16) {
-        IronCheckbox("Primary", isChecked: $primary, color: .primary)
-        IronCheckbox("Success", isChecked: $success, color: .success)
-        IronCheckbox("Warning", isChecked: $warning, color: .warning)
-        IronCheckbox("Error", isChecked: $error, color: .error)
-        IronCheckbox("Custom", isChecked: $custom, color: .custom(.purple))
-      }
-      .padding()
-    }
+  return VStack(alignment: .leading, spacing: 16) {
+    IronCheckbox("Primary", isChecked: $primary, color: .primary)
+    IronCheckbox("Success", isChecked: $success, color: .success)
+    IronCheckbox("Warning", isChecked: $warning, color: .warning)
+    IronCheckbox("Error", isChecked: $error, color: .error)
+    IronCheckbox("Custom", isChecked: $custom, color: .custom(.purple))
   }
-
-  return Demo()
+  .padding()
 }
 
 #Preview("IronCheckbox - Disabled") {
@@ -455,36 +425,30 @@ public enum IronCheckboxColor: Sendable {
 }
 
 #Preview("IronCheckbox - Form Example") {
-  struct Demo: View {
-    @State private var item1 = false
-    @State private var item2 = true
-    @State private var item3 = false
-    @State private var item4 = true
-    @State private var item5 = false
+  @Previewable @State var item1 = false
+  @Previewable @State var item2 = true
+  @Previewable @State var item3 = false
+  @Previewable @State var item4 = true
+  @Previewable @State var item5 = false
 
-    var body: some View {
-      VStack(alignment: .leading, spacing: 0) {
-        Text("Select Interests")
-          .font(.headline)
-          .padding(.bottom)
+  return VStack(alignment: .leading, spacing: 0) {
+    Text("Select Interests")
+      .font(.headline)
+      .padding(.bottom)
 
-        VStack(alignment: .leading, spacing: 12) {
-          IronCheckbox("Technology", isChecked: $item1)
-          IronCheckbox("Design", isChecked: $item2)
-          IronCheckbox("Business", isChecked: $item3)
-          IronCheckbox("Science", isChecked: $item4)
-          IronCheckbox("Arts", isChecked: $item5)
-        }
+    VStack(alignment: .leading, spacing: 12) {
+      IronCheckbox("Technology", isChecked: $item1)
+      IronCheckbox("Design", isChecked: $item2)
+      IronCheckbox("Business", isChecked: $item3)
+      IronCheckbox("Science", isChecked: $item4)
+      IronCheckbox("Arts", isChecked: $item5)
+    }
 
-        Spacer().frame(height: 24)
+    Spacer().frame(height: 24)
 
-        IronButton("Continue", isFullWidth: true) {
-          // Continue action
-        }
-      }
-      .padding()
+    IronButton("Continue", isFullWidth: true) {
+      // Continue action
     }
   }
-
-  return Demo()
+  .padding()
 }

--- a/Sources/IronPrimitives/ContextLine/IronContextLine.swift
+++ b/Sources/IronPrimitives/ContextLine/IronContextLine.swift
@@ -738,33 +738,27 @@ private struct IronContextGroupLayout: _VariadicView_UnaryViewRoot {
 }
 
 #Preview("IronContextLine - Animated") {
-  struct AnimatedDemo: View {
-    @State private var isRevealed = false
+  @Previewable @State var isRevealed = false
 
-    var body: some View {
-      VStack(alignment: .leading, spacing: 8) {
-        Button("Toggle Result") {
-          isRevealed.toggle()
-        }
-        .buttonStyle(.borderedProminent)
+  return VStack(alignment: .leading, spacing: 8) {
+    Button("Toggle Result") {
+      isRevealed.toggle()
+    }
+    .buttonStyle(.borderedProminent)
 
-        HStack(spacing: 8) {
-          Image(systemName: "terminal")
-          Text("Long running task")
-            .fontWeight(.medium)
-        }
+    HStack(spacing: 8) {
+      Image(systemName: "terminal")
+      Text("Long running task")
+        .fontWeight(.medium)
+    }
 
-        IronContextLine(isRevealed: $isRevealed) {
-          HStack(spacing: 4) {
-            Image(systemName: "checkmark.circle.fill")
-              .foregroundStyle(.green)
-            Text("Task completed!")
-          }
-        }
+    IronContextLine(isRevealed: $isRevealed) {
+      HStack(spacing: 4) {
+        Image(systemName: "checkmark.circle.fill")
+          .foregroundStyle(.green)
+        Text("Task completed!")
       }
-      .padding()
     }
   }
-
-  return AnimatedDemo()
+  .padding()
 }

--- a/Sources/IronPrimitives/Radio/IronRadio.swift
+++ b/Sources/IronPrimitives/Radio/IronRadio.swift
@@ -336,184 +336,142 @@ private enum SampleOption: String, CaseIterable {
 }
 
 #Preview("IronRadio - Basic") {
-  struct Demo: View {
-    @State private var selection = SampleOption.first
+  @Previewable @State var selection = SampleOption.first
 
-    var body: some View {
-      VStack(alignment: .leading, spacing: 16) {
-        IronRadio("First Option", value: SampleOption.first, selection: $selection)
-        IronRadio("Second Option", value: SampleOption.second, selection: $selection)
-        IronRadio("Third Option", value: SampleOption.third, selection: $selection)
-      }
-      .padding()
-    }
+  return VStack(alignment: .leading, spacing: 16) {
+    IronRadio("First Option", value: SampleOption.first, selection: $selection)
+    IronRadio("Second Option", value: SampleOption.second, selection: $selection)
+    IronRadio("Third Option", value: SampleOption.third, selection: $selection)
   }
-
-  return Demo()
+  .padding()
 }
 
 #Preview("IronRadio - Custom Labels") {
-  struct Demo: View {
-    enum Plan: String, CaseIterable {
-      case basic, pro, enterprise
-    }
-
-    @State private var plan = Plan.pro
-
-    var body: some View {
-      VStack(alignment: .leading, spacing: 16) {
-        IronRadio(value: Plan.basic, selection: $plan) {
-          VStack(alignment: .leading) {
-            Text("Basic")
-              .fontWeight(.medium)
-            Text("Free forever")
-              .font(.caption)
-              .foregroundStyle(.secondary)
-          }
-        }
-
-        IronRadio(value: Plan.pro, selection: $plan) {
-          VStack(alignment: .leading) {
-            Text("Pro")
-              .fontWeight(.medium)
-            Text("$9.99/month")
-              .font(.caption)
-              .foregroundStyle(.secondary)
-          }
-        }
-
-        IronRadio(value: Plan.enterprise, selection: $plan) {
-          VStack(alignment: .leading) {
-            Text("Enterprise")
-              .fontWeight(.medium)
-            Text("Contact sales")
-              .font(.caption)
-              .foregroundStyle(.secondary)
-          }
-        }
-      }
-      .padding()
-    }
+  enum Plan: String, CaseIterable {
+    case basic, pro, enterprise
   }
 
-  return Demo()
+  @Previewable @State var plan = Plan.pro
+
+  return VStack(alignment: .leading, spacing: 16) {
+    IronRadio(value: Plan.basic, selection: $plan) {
+      VStack(alignment: .leading) {
+        Text("Basic")
+          .fontWeight(.medium)
+        Text("Free forever")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      }
+    }
+
+    IronRadio(value: Plan.pro, selection: $plan) {
+      VStack(alignment: .leading) {
+        Text("Pro")
+          .fontWeight(.medium)
+        Text("$9.99/month")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      }
+    }
+
+    IronRadio(value: Plan.enterprise, selection: $plan) {
+      VStack(alignment: .leading) {
+        Text("Enterprise")
+          .fontWeight(.medium)
+        Text("Contact sales")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      }
+    }
+  }
+  .padding()
 }
 
 #Preview("IronRadio - Sizes") {
-  struct Demo: View {
-    @State private var selection = SampleOption.first
+  @Previewable @State var selection = SampleOption.first
 
-    var body: some View {
-      VStack(alignment: .leading, spacing: 24) {
-        IronRadio("Small", value: SampleOption.first, selection: $selection, size: .small)
-        IronRadio("Medium", value: SampleOption.second, selection: $selection, size: .medium)
-        IronRadio("Large", value: SampleOption.third, selection: $selection, size: .large)
-      }
-      .padding()
-    }
+  return VStack(alignment: .leading, spacing: 24) {
+    IronRadio("Small", value: SampleOption.first, selection: $selection, size: .small)
+    IronRadio("Medium", value: SampleOption.second, selection: $selection, size: .medium)
+    IronRadio("Large", value: SampleOption.third, selection: $selection, size: .large)
   }
-
-  return Demo()
+  .padding()
 }
 
 #Preview("IronRadio - Colors") {
-  struct Demo: View {
-    enum ColorOption: String, CaseIterable {
-      case primary, success, warning, error, custom
-    }
-
-    @State private var selection = ColorOption.primary
-
-    var body: some View {
-      VStack(alignment: .leading, spacing: 16) {
-        IronRadio("Primary", value: ColorOption.primary, selection: $selection, color: .primary)
-        IronRadio("Success", value: ColorOption.success, selection: $selection, color: .success)
-        IronRadio("Warning", value: ColorOption.warning, selection: $selection, color: .warning)
-        IronRadio("Error", value: ColorOption.error, selection: $selection, color: .error)
-        IronRadio("Custom", value: ColorOption.custom, selection: $selection, color: .custom(.purple))
-      }
-      .padding()
-    }
+  enum ColorOption: String, CaseIterable {
+    case primary, success, warning, error, custom
   }
 
-  return Demo()
+  @Previewable @State var selection = ColorOption.primary
+
+  return VStack(alignment: .leading, spacing: 16) {
+    IronRadio("Primary", value: ColorOption.primary, selection: $selection, color: .primary)
+    IronRadio("Success", value: ColorOption.success, selection: $selection, color: .success)
+    IronRadio("Warning", value: ColorOption.warning, selection: $selection, color: .warning)
+    IronRadio("Error", value: ColorOption.error, selection: $selection, color: .error)
+    IronRadio("Custom", value: ColorOption.custom, selection: $selection, color: .custom(.purple))
+  }
+  .padding()
 }
 
 #Preview("IronRadio - Disabled") {
-  struct Demo: View {
-    @State private var selection = SampleOption.first
+  @Previewable @State var selection = SampleOption.first
 
-    var body: some View {
-      VStack(alignment: .leading, spacing: 16) {
-        IronRadio("Enabled Selected", value: SampleOption.first, selection: $selection)
-        IronRadio("Enabled Unselected", value: SampleOption.second, selection: $selection)
-        IronRadio("Disabled Selected", value: SampleOption.first, selection: .constant(.first))
-          .disabled(true)
-        IronRadio("Disabled Unselected", value: SampleOption.second, selection: .constant(.first))
-          .disabled(true)
-      }
-      .padding()
-    }
+  return VStack(alignment: .leading, spacing: 16) {
+    IronRadio("Enabled Selected", value: SampleOption.first, selection: $selection)
+    IronRadio("Enabled Unselected", value: SampleOption.second, selection: $selection)
+    IronRadio("Disabled Selected", value: SampleOption.first, selection: .constant(.first))
+      .disabled(true)
+    IronRadio("Disabled Unselected", value: SampleOption.second, selection: .constant(.first))
+      .disabled(true)
   }
-
-  return Demo()
+  .padding()
 }
 
 #Preview("IronRadioGroup") {
-  struct Demo: View {
-    @State private var selection = SampleOption.second
+  @Previewable @State var selection = SampleOption.second
 
-    var body: some View {
-      VStack(alignment: .leading) {
-        Text("Select an option")
-          .font(.headline)
-          .padding(.bottom, 8)
+  return VStack(alignment: .leading) {
+    Text("Select an option")
+      .font(.headline)
+      .padding(.bottom, 8)
 
-        IronRadioGroup(selection: $selection) {
-          IronRadio("First Option", value: SampleOption.first, selection: $selection)
-          IronRadio("Second Option", value: SampleOption.second, selection: $selection)
-          IronRadio("Third Option", value: SampleOption.third, selection: $selection)
-        }
-      }
-      .padding()
+    IronRadioGroup(selection: $selection) {
+      IronRadio("First Option", value: SampleOption.first, selection: $selection)
+      IronRadio("Second Option", value: SampleOption.second, selection: $selection)
+      IronRadio("Third Option", value: SampleOption.third, selection: $selection)
     }
   }
-
-  return Demo()
+  .padding()
 }
 
 #Preview("IronRadio - Survey Example") {
-  struct Demo: View {
-    enum Rating: Int, CaseIterable {
-      case poor = 1
-      case fair = 2
-      case good = 3
-      case excellent = 4
-    }
-
-    @State private var rating = Rating.good
-
-    var body: some View {
-      VStack(alignment: .leading, spacing: 16) {
-        Text("How would you rate our service?")
-          .font(.headline)
-
-        IronRadioGroup(selection: $rating) {
-          IronRadio("Poor", value: Rating.poor, selection: $rating)
-          IronRadio("Fair", value: Rating.fair, selection: $rating)
-          IronRadio("Good", value: Rating.good, selection: $rating)
-          IronRadio("Excellent", value: Rating.excellent, selection: $rating)
-        }
-
-        Spacer().frame(height: 16)
-
-        IronButton("Submit", isFullWidth: true) {
-          // Submit action
-        }
-      }
-      .padding()
-    }
+  enum Rating: Int, CaseIterable {
+    case poor = 1
+    case fair = 2
+    case good = 3
+    case excellent = 4
   }
 
-  return Demo()
+  @Previewable @State var rating = Rating.good
+
+  return VStack(alignment: .leading, spacing: 16) {
+    Text("How would you rate our service?")
+      .font(.headline)
+
+    IronRadioGroup(selection: $rating) {
+      IronRadio("Poor", value: Rating.poor, selection: $rating)
+      IronRadio("Fair", value: Rating.fair, selection: $rating)
+      IronRadio("Good", value: Rating.good, selection: $rating)
+      IronRadio("Excellent", value: Rating.excellent, selection: $rating)
+    }
+
+    Spacer().frame(height: 16)
+
+    IronButton("Submit", isFullWidth: true) {
+      // Submit action
+    }
+  }
+  .padding()
 }

--- a/Sources/IronPrimitives/SecureField/IronSecureField.swift
+++ b/Sources/IronPrimitives/SecureField/IronSecureField.swift
@@ -342,146 +342,104 @@ public struct IronSecureField<Leading: View>: View {
 // MARK: - Previews
 
 #Preview("IronSecureField - Basic") {
-  struct Demo: View {
-    @State private var password = ""
+  @Previewable @State var password = ""
 
-    var body: some View {
-      VStack(spacing: 16) {
-        IronSecureField("Password", text: $password)
-        IronSecureField("With text", text: .constant("secret123"))
-      }
-      .padding()
-    }
+  return VStack(spacing: 16) {
+    IronSecureField("Password", text: $password)
+    IronSecureField("With text", text: .constant("secret123"))
   }
-
-  return Demo()
+  .padding()
 }
 
 #Preview("IronSecureField - Styles") {
-  struct Demo: View {
-    @State private var text1 = ""
-    @State private var text2 = ""
-    @State private var text3 = ""
+  @Previewable @State var text1 = ""
+  @Previewable @State var text2 = ""
+  @Previewable @State var text3 = ""
 
-    var body: some View {
-      VStack(spacing: 24) {
-        VStack(alignment: .leading) {
-          Text("Outlined").font(.caption).foregroundStyle(.secondary)
-          IronSecureField("Password", text: $text1, style: .outlined)
-        }
+  return VStack(spacing: 24) {
+    VStack(alignment: .leading) {
+      Text("Outlined").font(.caption).foregroundStyle(.secondary)
+      IronSecureField("Password", text: $text1, style: .outlined)
+    }
 
-        VStack(alignment: .leading) {
-          Text("Filled").font(.caption).foregroundStyle(.secondary)
-          IronSecureField("Password", text: $text2, style: .filled)
-        }
+    VStack(alignment: .leading) {
+      Text("Filled").font(.caption).foregroundStyle(.secondary)
+      IronSecureField("Password", text: $text2, style: .filled)
+    }
 
-        VStack(alignment: .leading) {
-          Text("Underlined").font(.caption).foregroundStyle(.secondary)
-          IronSecureField("Password", text: $text3, style: .underlined)
-        }
-      }
-      .padding()
+    VStack(alignment: .leading) {
+      Text("Underlined").font(.caption).foregroundStyle(.secondary)
+      IronSecureField("Password", text: $text3, style: .underlined)
     }
   }
-
-  return Demo()
+  .padding()
 }
 
 #Preview("IronSecureField - Sizes") {
-  struct Demo: View {
-    @State private var text = ""
+  @Previewable @State var text = ""
 
-    var body: some View {
-      VStack(spacing: 16) {
-        IronSecureField("Small", text: $text, size: .small)
-        IronSecureField("Medium", text: $text, size: .medium)
-        IronSecureField("Large", text: $text, size: .large)
-      }
-      .padding()
-    }
+  return VStack(spacing: 16) {
+    IronSecureField("Small", text: $text, size: .small)
+    IronSecureField("Medium", text: $text, size: .medium)
+    IronSecureField("Large", text: $text, size: .large)
   }
-
-  return Demo()
+  .padding()
 }
 
 #Preview("IronSecureField - States") {
-  struct Demo: View {
-    @State private var normal = ""
-    @State private var success = "strongPassword123!"
-    @State private var error = "weak"
+  @Previewable @State var normal = ""
+  @Previewable @State var success = "strongPassword123!"
+  @Previewable @State var error = "weak"
 
-    var body: some View {
-      VStack(spacing: 16) {
-        IronSecureField("Normal", text: $normal, state: .normal)
-        IronSecureField("Success", text: $success, state: .success)
-        IronSecureField("Error", text: $error, state: .error("Password must be at least 8 characters"))
-      }
-      .padding()
-    }
+  return VStack(spacing: 16) {
+    IronSecureField("Normal", text: $normal, state: .normal)
+    IronSecureField("Success", text: $success, state: .success)
+    IronSecureField("Error", text: $error, state: .error("Password must be at least 8 characters"))
   }
-
-  return Demo()
+  .padding()
 }
 
 #Preview("IronSecureField - With Leading Icon") {
-  struct Demo: View {
-    @State private var password = ""
+  @Previewable @State var password = ""
 
-    var body: some View {
-      VStack(spacing: 16) {
-        IronSecureField("Password", text: $password, leading: {
-          Image(systemName: "lock")
-        })
+  return VStack(spacing: 16) {
+    IronSecureField("Password", text: $password, leading: {
+      Image(systemName: "lock")
+    })
 
-        IronSecureField("PIN", text: $password, leading: {
-          Image(systemName: "number")
-        })
-      }
-      .padding()
-    }
+    IronSecureField("PIN", text: $password, leading: {
+      Image(systemName: "number")
+    })
   }
-
-  return Demo()
+  .padding()
 }
 
 #Preview("IronSecureField - Without Toggle") {
-  struct Demo: View {
-    @State private var password = ""
+  @Previewable @State var password = ""
 
-    var body: some View {
-      VStack(spacing: 16) {
-        IronSecureField("With toggle", text: $password, showToggle: true)
-        IronSecureField("Without toggle", text: $password, showToggle: false)
-      }
-      .padding()
-    }
+  return VStack(spacing: 16) {
+    IronSecureField("With toggle", text: $password, showToggle: true)
+    IronSecureField("Without toggle", text: $password, showToggle: false)
   }
-
-  return Demo()
+  .padding()
 }
 
 #Preview("IronSecureField - Login Form") {
-  struct Demo: View {
-    @State private var email = ""
-    @State private var password = ""
+  @Previewable @State var email = ""
+  @Previewable @State var password = ""
 
-    var body: some View {
-      VStack(spacing: 16) {
-        IronTextField("Email", text: $email, leading: {
-          Image(systemName: "envelope")
-        })
+  return VStack(spacing: 16) {
+    IronTextField("Email", text: $email, leading: {
+      Image(systemName: "envelope")
+    })
 
-        IronSecureField("Password", text: $password, leading: {
-          Image(systemName: "lock")
-        })
+    IronSecureField("Password", text: $password, leading: {
+      Image(systemName: "lock")
+    })
 
-        IronButton("Sign In", isFullWidth: true) {
-          // Sign in action
-        }
-      }
-      .padding()
+    IronButton("Sign In", isFullWidth: true) {
+      // Sign in action
     }
   }
-
-  return Demo()
+  .padding()
 }

--- a/Sources/IronPrimitives/TextField/IronTextField.swift
+++ b/Sources/IronPrimitives/TextField/IronTextField.swift
@@ -424,129 +424,99 @@ public enum IronTextFieldState: Sendable, Equatable {
 // MARK: - Previews
 
 #Preview("IronTextField - Basic") {
-  struct Demo: View {
-    @State private var text = ""
+  @Previewable @State var text = ""
 
-    var body: some View {
-      VStack(spacing: 16) {
-        IronTextField("Enter your name", text: $text)
-        IronTextField("With some text", text: .constant("Hello World"))
-      }
-      .padding()
-    }
+  return VStack(spacing: 16) {
+    IronTextField("Enter your name", text: $text)
+    IronTextField("With some text", text: .constant("Hello World"))
   }
-
-  return Demo()
+  .padding()
 }
 
 #Preview("IronTextField - Styles") {
-  struct Demo: View {
-    @State private var text1 = ""
-    @State private var text2 = ""
-    @State private var text3 = ""
+  @Previewable @State var text1 = ""
+  @Previewable @State var text2 = ""
+  @Previewable @State var text3 = ""
 
-    var body: some View {
-      VStack(spacing: 24) {
-        VStack(alignment: .leading) {
-          Text("Outlined").font(.caption).foregroundStyle(.secondary)
-          IronTextField("Outlined style", text: $text1, style: .outlined)
-        }
+  return VStack(spacing: 24) {
+    VStack(alignment: .leading) {
+      Text("Outlined").font(.caption).foregroundStyle(.secondary)
+      IronTextField("Outlined style", text: $text1, style: .outlined)
+    }
 
-        VStack(alignment: .leading) {
-          Text("Filled").font(.caption).foregroundStyle(.secondary)
-          IronTextField("Filled style", text: $text2, style: .filled)
-        }
+    VStack(alignment: .leading) {
+      Text("Filled").font(.caption).foregroundStyle(.secondary)
+      IronTextField("Filled style", text: $text2, style: .filled)
+    }
 
-        VStack(alignment: .leading) {
-          Text("Underlined").font(.caption).foregroundStyle(.secondary)
-          IronTextField("Underlined style", text: $text3, style: .underlined)
-        }
-      }
-      .padding()
+    VStack(alignment: .leading) {
+      Text("Underlined").font(.caption).foregroundStyle(.secondary)
+      IronTextField("Underlined style", text: $text3, style: .underlined)
     }
   }
-
-  return Demo()
+  .padding()
 }
 
 #Preview("IronTextField - Sizes") {
-  struct Demo: View {
-    @State private var text = ""
+  @Previewable @State var text = ""
 
-    var body: some View {
-      VStack(spacing: 16) {
-        IronTextField("Small", text: $text, size: .small)
-        IronTextField("Medium", text: $text, size: .medium)
-        IronTextField("Large", text: $text, size: .large)
-      }
-      .padding()
-    }
+  return VStack(spacing: 16) {
+    IronTextField("Small", text: $text, size: .small)
+    IronTextField("Medium", text: $text, size: .medium)
+    IronTextField("Large", text: $text, size: .large)
   }
-
-  return Demo()
+  .padding()
 }
 
 #Preview("IronTextField - States") {
-  struct Demo: View {
-    @State private var normal = ""
-    @State private var success = "valid@email.com"
-    @State private var error = "invalid"
+  @Previewable @State var normal = ""
+  @Previewable @State var success = "valid@email.com"
+  @Previewable @State var error = "invalid"
 
-    var body: some View {
-      VStack(spacing: 16) {
-        IronTextField("Normal", text: $normal, state: .normal)
-        IronTextField("Success", text: $success, state: .success)
-        IronTextField("Error", text: $error, state: .error("Please enter a valid email"))
-      }
-      .padding()
-    }
+  return VStack(spacing: 16) {
+    IronTextField("Normal", text: $normal, state: .normal)
+    IronTextField("Success", text: $success, state: .success)
+    IronTextField("Error", text: $error, state: .error("Please enter a valid email"))
   }
-
-  return Demo()
+  .padding()
 }
 
 #Preview("IronTextField - With Icons") {
-  struct Demo: View {
-    @State private var email = ""
-    @State private var search = ""
-    @State private var password = ""
-    @State private var showPassword = false
+  @Previewable @State var email = ""
+  @Previewable @State var search = ""
+  @Previewable @State var password = ""
+  @Previewable @State var showPassword = false
 
-    var body: some View {
-      VStack(spacing: 16) {
-        IronTextField("Email", text: $email, leading: {
-          Image(systemName: "envelope")
-        })
+  return VStack(spacing: 16) {
+    IronTextField("Email", text: $email, leading: {
+      Image(systemName: "envelope")
+    })
 
-        IronTextField("Search", text: $search, leading: {
-          Image(systemName: "magnifyingglass")
-        }, trailing: {
-          if !search.isEmpty {
-            Button {
-              search = ""
-            } label: {
-              Image(systemName: "xmark.circle.fill")
-            }
-            .buttonStyle(.plain)
-          }
-        })
-
-        IronTextField("Password", text: $password, leading: {
-          Image(systemName: "lock")
-        }, trailing: {
-          Button {
-            showPassword.toggle()
-          } label: {
-            Image(systemName: showPassword ? "eye.slash" : "eye")
-          }
-          .buttonStyle(.plain)
-        })
+    IronTextField("Search", text: $search, leading: {
+      Image(systemName: "magnifyingglass")
+    }, trailing: {
+      if !search.isEmpty {
+        Button {
+          search = ""
+        } label: {
+          Image(systemName: "xmark.circle.fill")
+        }
+        .buttonStyle(.plain)
       }
-      .padding()
-    }
-  }
+    })
 
-  return Demo()
+    IronTextField("Password", text: $password, leading: {
+      Image(systemName: "lock")
+    }, trailing: {
+      Button {
+        showPassword.toggle()
+      } label: {
+        Image(systemName: showPassword ? "eye.slash" : "eye")
+      }
+      .buttonStyle(.plain)
+    })
+  }
+  .padding()
 }
 
 #Preview("IronTextField - Disabled") {
@@ -564,34 +534,28 @@ public enum IronTextFieldState: Sendable, Equatable {
 }
 
 #Preview("IronTextField - Form Example") {
-  struct Demo: View {
-    @State private var firstName = ""
-    @State private var lastName = ""
-    @State private var email = ""
-    @State private var phone = ""
+  @Previewable @State var firstName = ""
+  @Previewable @State var lastName = ""
+  @Previewable @State var email = ""
+  @Previewable @State var phone = ""
 
-    var body: some View {
-      VStack(spacing: 16) {
-        HStack(spacing: 12) {
-          IronTextField("First name", text: $firstName)
-          IronTextField("Last name", text: $lastName)
-        }
+  return VStack(spacing: 16) {
+    HStack(spacing: 12) {
+      IronTextField("First name", text: $firstName)
+      IronTextField("Last name", text: $lastName)
+    }
 
-        IronTextField("Email", text: $email, leading: {
-          Image(systemName: "envelope")
-        })
+    IronTextField("Email", text: $email, leading: {
+      Image(systemName: "envelope")
+    })
 
-        IronTextField("Phone", text: $phone, leading: {
-          Image(systemName: "phone")
-        })
+    IronTextField("Phone", text: $phone, leading: {
+      Image(systemName: "phone")
+    })
 
-        IronButton("Submit", isFullWidth: true) {
-          // Submit action
-        }
-      }
-      .padding()
+    IronButton("Submit", isFullWidth: true) {
+      // Submit action
     }
   }
-
-  return Demo()
+  .padding()
 }

--- a/Sources/IronPrimitives/Toggle/IronToggle.swift
+++ b/Sources/IronPrimitives/Toggle/IronToggle.swift
@@ -403,148 +403,117 @@ public enum IronToggleColor: Sendable {
 // MARK: - Previews
 
 #Preview("IronToggle - Basic") {
-  struct Demo: View {
-    @State private var isOn = false
-    @State private var isEnabled = true
+  @Previewable @State var isOn = false
 
-    var body: some View {
-      VStack(spacing: 24) {
-        IronToggle(isOn: $isOn)
+  return VStack(spacing: 24) {
+    IronToggle(isOn: $isOn)
 
-        IronToggle(isOn: .constant(true))
-        IronToggle(isOn: .constant(false))
-      }
-      .padding()
-    }
+    IronToggle(isOn: .constant(true))
+    IronToggle(isOn: .constant(false))
   }
-
-  return Demo()
+  .padding()
 }
 
 #Preview("IronToggle - With Labels") {
-  struct Demo: View {
-    @State private var darkMode = false
-    @State private var notifications = true
-    @State private var analytics = false
+  @Previewable @State var darkMode = false
+  @Previewable @State var notifications = true
+  @Previewable @State var analytics = false
 
-    var body: some View {
-      VStack(spacing: 16) {
-        IronToggle("Dark Mode", isOn: $darkMode)
-        IronToggle("Notifications", isOn: $notifications)
-        IronToggle("Analytics", isOn: $analytics)
-      }
-      .padding()
-    }
+  return VStack(spacing: 16) {
+    IronToggle("Dark Mode", isOn: $darkMode)
+    IronToggle("Notifications", isOn: $notifications)
+    IronToggle("Analytics", isOn: $analytics)
   }
-
-  return Demo()
+  .padding()
 }
 
 #Preview("IronToggle - Custom Labels") {
-  struct Demo: View {
-    @State private var wifi = true
-    @State private var bluetooth = false
-    @State private var airplane = false
+  @Previewable @State var wifi = true
+  @Previewable @State var bluetooth = false
+  @Previewable @State var airplane = false
 
-    var body: some View {
-      VStack(spacing: 16) {
-        IronToggle(isOn: $wifi) {
-          Label("Wi-Fi", systemImage: "wifi")
-        }
+  return VStack(spacing: 16) {
+    IronToggle(isOn: $wifi) {
+      Label("Wi-Fi", systemImage: "wifi")
+    }
 
-        IronToggle(isOn: $bluetooth) {
-          Label("Bluetooth", systemImage: "wave.3.right")
-        }
+    IronToggle(isOn: $bluetooth) {
+      Label("Bluetooth", systemImage: "wave.3.right")
+    }
 
-        IronToggle(isOn: $airplane) {
-          Label("Airplane Mode", systemImage: "airplane")
-        }
-      }
-      .padding()
+    IronToggle(isOn: $airplane) {
+      Label("Airplane Mode", systemImage: "airplane")
     }
   }
-
-  return Demo()
+  .padding()
 }
 
 #Preview("IronToggle - Sizes") {
-  struct Demo: View {
-    @State private var small = true
-    @State private var medium = true
-    @State private var large = true
+  @Previewable @State var small = true
+  @Previewable @State var medium = true
+  @Previewable @State var large = true
 
-    var body: some View {
-      VStack(spacing: 24) {
-        HStack {
-          Text("Small")
-          Spacer()
-          IronToggle(isOn: $small, size: .small)
-        }
+  return VStack(spacing: 24) {
+    HStack {
+      Text("Small")
+      Spacer()
+      IronToggle(isOn: $small, size: .small)
+    }
 
-        HStack {
-          Text("Medium")
-          Spacer()
-          IronToggle(isOn: $medium, size: .medium)
-        }
+    HStack {
+      Text("Medium")
+      Spacer()
+      IronToggle(isOn: $medium, size: .medium)
+    }
 
-        HStack {
-          Text("Large")
-          Spacer()
-          IronToggle(isOn: $large, size: .large)
-        }
-      }
-      .padding()
+    HStack {
+      Text("Large")
+      Spacer()
+      IronToggle(isOn: $large, size: .large)
     }
   }
-
-  return Demo()
+  .padding()
 }
 
 #Preview("IronToggle - Colors") {
-  struct Demo: View {
-    @State private var primary = true
-    @State private var success = true
-    @State private var warning = true
-    @State private var error = true
-    @State private var custom = true
+  @Previewable @State var primary = true
+  @Previewable @State var success = true
+  @Previewable @State var warning = true
+  @Previewable @State var error = true
+  @Previewable @State var custom = true
 
-    var body: some View {
-      VStack(spacing: 16) {
-        HStack {
-          Text("Primary")
-          Spacer()
-          IronToggle(isOn: $primary, color: .primary)
-        }
+  return VStack(spacing: 16) {
+    HStack {
+      Text("Primary")
+      Spacer()
+      IronToggle(isOn: $primary, color: .primary)
+    }
 
-        HStack {
-          Text("Success")
-          Spacer()
-          IronToggle(isOn: $success, color: .success)
-        }
+    HStack {
+      Text("Success")
+      Spacer()
+      IronToggle(isOn: $success, color: .success)
+    }
 
-        HStack {
-          Text("Warning")
-          Spacer()
-          IronToggle(isOn: $warning, color: .warning)
-        }
+    HStack {
+      Text("Warning")
+      Spacer()
+      IronToggle(isOn: $warning, color: .warning)
+    }
 
-        HStack {
-          Text("Error")
-          Spacer()
-          IronToggle(isOn: $error, color: .error)
-        }
+    HStack {
+      Text("Error")
+      Spacer()
+      IronToggle(isOn: $error, color: .error)
+    }
 
-        HStack {
-          Text("Custom")
-          Spacer()
-          IronToggle(isOn: $custom, color: .custom(.purple))
-        }
-      }
-      .padding()
+    HStack {
+      Text("Custom")
+      Spacer()
+      IronToggle(isOn: $custom, color: .custom(.purple))
     }
   }
-
-  return Demo()
+  .padding()
 }
 
 #Preview("IronToggle - Disabled") {
@@ -561,28 +530,6 @@ public enum IronToggleColor: Sendable {
 }
 
 #Preview("IronToggle - Settings Example") {
-  struct Demo: View {
-    @State private var notifications = true
-    @State private var sounds = true
-    @State private var haptics = false
-    @State private var autoUpdate = true
-
-    var body: some View {
-      VStack(spacing: 0) {
-        SettingsRow(title: "Push Notifications", isOn: $notifications)
-        Divider().padding(.leading)
-        SettingsRow(title: "Sound Effects", isOn: $sounds)
-        Divider().padding(.leading)
-        SettingsRow(title: "Haptic Feedback", isOn: $haptics)
-        Divider().padding(.leading)
-        SettingsRow(title: "Auto-Update", isOn: $autoUpdate)
-      }
-      .background(Color.white)
-      .clipShape(RoundedRectangle(cornerRadius: 12))
-      .padding()
-    }
-  }
-
   struct SettingsRow: View {
     let title: String
     @Binding var isOn: Bool
@@ -593,5 +540,21 @@ public enum IronToggleColor: Sendable {
     }
   }
 
-  return Demo()
+  @Previewable @State var notifications = true
+  @Previewable @State var sounds = true
+  @Previewable @State var haptics = false
+  @Previewable @State var autoUpdate = true
+
+  return VStack(spacing: 0) {
+    SettingsRow(title: "Push Notifications", isOn: $notifications)
+    Divider().padding(.leading)
+    SettingsRow(title: "Sound Effects", isOn: $sounds)
+    Divider().padding(.leading)
+    SettingsRow(title: "Haptic Feedback", isOn: $haptics)
+    Divider().padding(.leading)
+    SettingsRow(title: "Auto-Update", isOn: $autoUpdate)
+  }
+  .background(Color.white)
+  .clipShape(RoundedRectangle(cornerRadius: 12))
+  .padding()
 }


### PR DESCRIPTION
## Summary
- move preview state to `@Previewable` at the preview block root
- remove nested preview demo structs to satisfy preview macro rules
- align previews with repo preview guidelines

## Testing
- `swift run ironui-cli build` (warnings about unused locals in existing code)

## Notes
- `.vscode/` left untracked as requested