### PR TITLE
fix: align API naming with ADR-0006 conventions

### DIFF
--- a/Sources/IronComponents/Chip/IronChip.swift
+++ b/Sources/IronComponents/Chip/IronChip.swift
@@ -508,5 +508,4 @@ public enum IronChipSize: Sendable, CaseIterable {
     }
   }
   .padding()
-
 }

--- a/Sources/IronComponents/Menu/IronMenu.swift
+++ b/Sources/IronComponents/Menu/IronMenu.swift
@@ -181,17 +181,17 @@ public struct IronMenuItem: View {
   ///   - title: The item title.
   ///   - icon: Optional SF Symbol name.
   ///   - role: The button role (e.g., destructive).
-  ///   - action: The action to perform.
+  ///   - onTap: The action to perform.
   public init(
     _ title: LocalizedStringKey,
     icon: String? = nil,
     role: ButtonRole? = nil,
-    action: @escaping () -> Void,
+    onTap: @escaping () -> Void,
   ) {
     self.title = title
     self.icon = icon
     self.role = role
-    self.action = action
+    self.onTap = onTap
   }
 
   /// Creates a menu item from a string.
@@ -200,24 +200,24 @@ public struct IronMenuItem: View {
   ///   - title: The item title string.
   ///   - icon: Optional SF Symbol name.
   ///   - role: The button role (e.g., destructive).
-  ///   - action: The action to perform.
+  ///   - onTap: The action to perform.
   public init(
     _ title: some StringProtocol,
     icon: String? = nil,
     role: ButtonRole? = nil,
-    action: @escaping () -> Void,
+    onTap: @escaping () -> Void,
   ) {
     self.title = LocalizedStringKey(String(title))
     self.icon = icon
     self.role = role
-    self.action = action
+    self.onTap = onTap
   }
 
   // MARK: Public
 
   public var body: some View {
     Button(role: role) {
-      action()
+      onTap()
       IronLogger.ui.debug(
         "IronMenuItem tapped",
         metadata: ["role": .string("\(String(describing: role))")],
@@ -240,7 +240,7 @@ public struct IronMenuItem: View {
   private let title: LocalizedStringKey
   private let icon: String?
   private let role: ButtonRole?
-  private let action: () -> Void
+  private let onTap: () -> Void
 }
 
 // MARK: - IronMenuSection

--- a/Sources/IronComponents/Skeleton/IronSkeleton.swift
+++ b/Sources/IronComponents/Skeleton/IronSkeleton.swift
@@ -45,13 +45,13 @@ public struct IronSkeleton: View {
   ///
   /// - Parameters:
   ///   - shape: The shape of the skeleton.
-  ///   - animated: Whether to show the shimmer animation.
+  ///   - isAnimated: Whether to show the shimmer animation.
   public init(
     shape: IronSkeletonShape,
-    animated: Bool = true,
+    isAnimated: Bool = true,
   ) {
     self.shape = shape
-    self.animated = animated
+    self.isAnimated = isAnimated
   }
 
   // MARK: Public
@@ -60,7 +60,7 @@ public struct IronSkeleton: View {
     skeletonContent
       .accessibilityElement(children: .ignore)
       .accessibilityLabel("Loading")
-      .accessibilityAddTraits(animated ? .updatesFrequently : [])
+      .accessibilityAddTraits(isAnimated ? .updatesFrequently : [])
   }
 
   // MARK: Private
@@ -72,7 +72,7 @@ public struct IronSkeleton: View {
   @State private var shimmerOffset: CGFloat = -1
 
   private let shape: IronSkeletonShape
-  private let animated: Bool
+  private let isAnimated: Bool
 
   @ViewBuilder
   private var skeletonContent: some View {
@@ -148,7 +148,7 @@ public struct IronSkeleton: View {
   }
 
   private var shouldAnimate: Bool {
-    animated && !reduceMotion && !skipEntranceAnimations
+    isAnimated && !reduceMotion && !skipEntranceAnimations
   }
 
   private func skeletonView(
@@ -256,16 +256,16 @@ public struct IronSkeletonCard: View {
 
   /// Creates a skeleton card.
   ///
-  /// - Parameter showImage: Whether to show an image placeholder.
-  public init(showImage: Bool = true) {
-    self.showImage = showImage
+  /// - Parameter isImageVisible: Whether to show an image placeholder.
+  public init(isImageVisible: Bool = true) {
+    self.isImageVisible = isImageVisible
   }
 
   // MARK: Public
 
   public var body: some View {
     VStack(alignment: .leading, spacing: theme.spacing.md) {
-      if showImage {
+      if isImageVisible {
         IronSkeleton(shape: .rectangle(width: .infinity, height: 150))
           .frame(maxWidth: .infinity)
           .frame(height: 150)
@@ -291,7 +291,7 @@ public struct IronSkeletonCard: View {
 
   @Environment(\.ironTheme) private var theme
 
-  private let showImage: Bool
+  private let isImageVisible: Bool
 }
 
 // MARK: - IronSkeletonList
@@ -401,8 +401,8 @@ public struct IronSkeletonListItem: View {
 
 #Preview("IronSkeleton - Static (No Animation)") {
   VStack(spacing: 16) {
-    IronSkeleton(shape: .rounded(width: 200, height: 20, radius: 4), animated: false)
-    IronSkeleton(shape: .circle(size: 48), animated: false)
+    IronSkeleton(shape: .rounded(width: 200, height: 20, radius: 4), isAnimated: false)
+    IronSkeleton(shape: .circle(size: 48), isAnimated: false)
   }
   .padding()
 }

--- a/Sources/IronCore/Interactions/IronHaptics.swift
+++ b/Sources/IronCore/Interactions/IronHaptics.swift
@@ -255,28 +255,28 @@ public struct IronSensoryFeedbackModifier: ViewModifier {
   // MARK: Lifecycle
 
   public init(
-    trigger: Bool,
-    haptic: @escaping () -> Void,
+    isTriggered: Bool,
+    onTrigger: @escaping () -> Void,
   ) {
-    self.trigger = trigger
-    self.haptic = haptic
+    self.isTriggered = isTriggered
+    self.onTrigger = onTrigger
   }
 
   // MARK: Public
 
   public func body(content: Content) -> some View {
     content
-      .onChange(of: trigger) { _, newValue in
+      .onChange(of: isTriggered) { _, newValue in
         if newValue {
-          haptic()
+          onTrigger()
         }
       }
   }
 
   // MARK: Private
 
-  private let trigger: Bool
-  private let haptic: () -> Void
+  private let isTriggered: Bool
+  private let onTrigger: () -> Void
 }
 
 extension View {
@@ -286,23 +286,23 @@ extension View {
   ///
   /// ```swift
   /// ContentView()
-  ///   .ironSensoryFeedback(trigger: isComplete) {
+  ///   .ironSensoryFeedback(isTriggered: isComplete) {
   ///     IronHaptics.success()
   ///   }
   /// ```
   ///
   /// - Parameters:
-  ///   - trigger: Condition that triggers the haptic.
-  ///   - haptic: The haptic feedback to trigger.
+  ///   - isTriggered: Condition that triggers the haptic.
+  ///   - onTrigger: The haptic feedback to trigger.
   /// - Returns: A view with sensory feedback.
   public func ironSensoryFeedback(
-    trigger: Bool,
-    haptic: @escaping () -> Void,
+    isTriggered: Bool,
+    onTrigger: @escaping () -> Void,
   ) -> some View {
     modifier(
       IronSensoryFeedbackModifier(
-        trigger: trigger,
-        haptic: haptic,
+        isTriggered: isTriggered,
+        onTrigger: onTrigger,
       )
     )
   }

--- a/Sources/IronCore/Interactions/IronShake.swift
+++ b/Sources/IronCore/Interactions/IronShake.swift
@@ -13,7 +13,7 @@ import SwiftUI
 /// @State private var shake = false
 ///
 /// TextField("Password", text: $password)
-///   .ironShake(active: shake)
+///   .ironShake(isActive: $shake)
 ///
 /// // Trigger on error
 /// if passwordWrong {
@@ -24,9 +24,9 @@ import SwiftUI
 /// ## Shake Styles
 ///
 /// ```swift
-/// .ironShake(active: shake, style: .subtle)   // Gentle nudge
-/// .ironShake(active: shake, style: .standard) // Normal shake
-/// .ironShake(active: shake, style: .intense)  // Urgent attention
+/// .ironShake(isActive: $shake, style: .subtle)   // Gentle nudge
+/// .ironShake(isActive: $shake, style: .standard) // Normal shake
+/// .ironShake(isActive: $shake, style: .intense)  // Urgent attention
 /// ```
 public struct IronShakeModifier: ViewModifier {
 
@@ -35,15 +35,15 @@ public struct IronShakeModifier: ViewModifier {
   /// Creates a shake modifier.
   ///
   /// - Parameters:
-  ///   - active: When true, triggers the shake animation.
+  ///   - isActive: When true, triggers the shake animation.
   ///   - style: The intensity of the shake.
   ///   - onComplete: Called when the shake animation finishes.
   public init(
-    active: Binding<Bool>,
+    isActive: Binding<Bool>,
     style: IronShakeStyle = .standard,
     onComplete: (() -> Void)? = nil,
   ) {
-    _active = active
+    _isActive = isActive
     self.style = style
     self.onComplete = onComplete
   }
@@ -56,12 +56,12 @@ public struct IronShakeModifier: ViewModifier {
         trigger: animationTrigger,
         intensity: style.intensity,
       ))
-      .onChange(of: active) { _, newValue in
+      .onChange(of: isActive) { _, newValue in
         if newValue {
           animationTrigger += 1
           // Reset after animation completes
           DispatchQueue.main.asyncAfter(deadline: .now() + style.duration) {
-            active = false
+            isActive = false
             onComplete?()
           }
         }
@@ -70,7 +70,7 @@ public struct IronShakeModifier: ViewModifier {
 
   // MARK: Private
 
-  @Binding private var active: Bool
+  @Binding private var isActive: Bool
   @State private var animationTrigger = 0
 
   private let style: IronShakeStyle
@@ -175,32 +175,32 @@ public enum IronShakeStyle: Sendable {
 extension View {
   /// Adds a shake animation for attention feedback.
   ///
-  /// When `active` becomes true, the view shakes horizontally
+  /// When `isActive` becomes true, the view shakes horizontally
   /// and then returns to its original position.
   ///
   /// ```swift
   /// @State private var shake = false
   ///
   /// TextField("Code", text: $code)
-  ///   .ironShake(active: $shake)
+  ///   .ironShake(isActive: $shake)
   ///   .onChange(of: isInvalid) { _, invalid in
   ///     if invalid { shake = true }
   ///   }
   /// ```
   ///
   /// - Parameters:
-  ///   - active: Binding that triggers shake when true.
+  ///   - isActive: Binding that triggers shake when true.
   ///   - style: The shake intensity.
   ///   - onComplete: Called when shake finishes.
   /// - Returns: A view with shake capability.
   public func ironShake(
-    active: Binding<Bool>,
+    isActive: Binding<Bool>,
     style: IronShakeStyle = .standard,
     onComplete: (() -> Void)? = nil,
   ) -> some View {
     modifier(
       IronShakeModifier(
-        active: active,
+        isActive: isActive,
         style: style,
         onComplete: onComplete,
       )
@@ -217,18 +217,18 @@ extension View {
 ///
 /// ```swift
 /// TrashIcon()
-///   .ironWiggle(active: trashIsFull)
+///   .ironWiggle(isActive: trashIsFull)
 /// ```
 public struct IronWiggleModifier: ViewModifier {
 
   // MARK: Lifecycle
 
   public init(
-    active: Bool,
+    isActive: Bool,
     intensity: Double = 3,
     speed: Double = 0.1,
   ) {
-    self.active = active
+    self.isActive = isActive
     self.intensity = intensity
     self.speed = speed
   }
@@ -236,7 +236,7 @@ public struct IronWiggleModifier: ViewModifier {
   // MARK: Public
 
   public func body(content: Content) -> some View {
-    if active {
+    if isActive {
       content
         .phaseAnimator(WigglePhase.allCases) { view, phase in
           view.rotationEffect(.degrees(phase == .left ? -intensity : intensity))
@@ -259,7 +259,7 @@ public struct IronWiggleModifier: ViewModifier {
 
   // MARK: Private
 
-  private let active: Bool
+  private let isActive: Bool
   private let intensity: Double
   private let speed: Double
 }
@@ -272,22 +272,22 @@ extension View {
   ///
   /// ```swift
   /// Image(systemName: "trash.fill")
-  ///   .ironWiggle(active: trashNeedsEmptying)
+  ///   .ironWiggle(isActive: trashNeedsEmptying)
   /// ```
   ///
   /// - Parameters:
-  ///   - active: Whether the wiggle is animating.
+  ///   - isActive: Whether the wiggle is animating.
   ///   - intensity: Rotation angle in degrees.
   ///   - speed: Time for one wiggle direction.
   /// - Returns: A view with wiggle animation.
   public func ironWiggle(
-    active: Bool,
+    isActive: Bool,
     intensity: Double = 3,
     speed: Double = 0.1,
   ) -> some View {
     modifier(
       IronWiggleModifier(
-        active: active,
+        isActive: isActive,
         intensity: intensity,
         speed: speed,
       )
@@ -301,17 +301,17 @@ extension View {
 ///
 /// ```swift
 /// NotificationBadge()
-///   .ironBounce(active: hasNewNotification)
+///   .ironBounce(isActive: $hasNewNotification)
 /// ```
 public struct IronBounceModifier: ViewModifier {
 
   // MARK: Lifecycle
 
   public init(
-    active: Binding<Bool>,
+    isActive: Binding<Bool>,
     intensity: CGFloat = 0.3,
   ) {
-    _active = active
+    _isActive = isActive
     self.intensity = intensity
   }
 
@@ -320,12 +320,12 @@ public struct IronBounceModifier: ViewModifier {
   public func body(content: Content) -> some View {
     content
       .modifier(BounceAnimationModifier(trigger: animationTrigger, intensity: intensity))
-      .onChange(of: active) { _, newValue in
+      .onChange(of: isActive) { _, newValue in
         if newValue {
           animationTrigger += 1
-          // Reset active after animation
+          // Reset isActive after animation
           DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            active = false
+            isActive = false
           }
         }
       }
@@ -333,7 +333,7 @@ public struct IronBounceModifier: ViewModifier {
 
   // MARK: Private
 
-  @Binding private var active: Bool
+  @Binding private var isActive: Bool
   @State private var animationTrigger = 0
 
   private let intensity: CGFloat
@@ -381,16 +381,16 @@ extension View {
   /// with spring physics.
   ///
   /// - Parameters:
-  ///   - active: Binding that triggers bounce when true.
+  ///   - isActive: Binding that triggers bounce when true.
   ///   - intensity: Scale increase (0.3 = 30% larger).
   /// - Returns: A view with bounce animation.
   public func ironBounce(
-    active: Binding<Bool>,
+    isActive: Binding<Bool>,
     intensity: CGFloat = 0.3,
   ) -> some View {
     modifier(
       IronBounceModifier(
-        active: active,
+        isActive: isActive,
         intensity: intensity,
       )
     )
@@ -410,16 +410,16 @@ extension View {
 
     Button("Subtle") { shakeSubtle = true }
       .buttonStyle(.borderedProminent)
-      .ironShake(active: $shakeSubtle, style: .subtle)
+      .ironShake(isActive: $shakeSubtle, style: .subtle)
 
     Button("Standard") { shakeStandard = true }
       .buttonStyle(.borderedProminent)
-      .ironShake(active: $shakeStandard, style: .standard)
+      .ironShake(isActive: $shakeStandard, style: .standard)
 
     Button("Intense") { shakeIntense = true }
       .buttonStyle(.borderedProminent)
       .tint(.red)
-      .ironShake(active: $shakeIntense, style: .intense)
+      .ironShake(isActive: $shakeIntense, style: .intense)
   }
   .padding()
 }
@@ -436,7 +436,7 @@ extension View {
     SecureField("Password", text: $password)
       .textFieldStyle(.roundedBorder)
       .padding(.horizontal, 40)
-      .ironShake(active: $shake, style: .standard)
+      .ironShake(isActive: $shake, style: .standard)
 
     if showError {
       Text("Wrong password!")
@@ -464,7 +464,7 @@ extension View {
     Image(systemName: "trash.fill")
       .font(.system(size: 50))
       .foregroundStyle(trashFull ? .red : .secondary)
-      .ironWiggle(active: trashFull)
+      .ironWiggle(isActive: trashFull)
   }
   .padding()
 }
@@ -486,7 +486,7 @@ extension View {
           .foregroundStyle(.pink)
       }
       .buttonStyle(.plain)
-      .ironBounce(active: $bounce)
+      .ironBounce(isActive: $bounce)
 
       // Star button with separate state
       BounceableButton(
@@ -524,7 +524,7 @@ private struct BounceableButton: View {
         .foregroundStyle(color)
     }
     .buttonStyle(.plain)
-    .ironBounce(active: $bounce)
+    .ironBounce(isActive: $bounce)
   }
 
   @State private var bounce = false

--- a/Sources/IronCore/Interactions/IronShimmer.swift
+++ b/Sources/IronCore/Interactions/IronShimmer.swift
@@ -15,7 +15,7 @@ import SwiftUI
 ///
 /// // Conditional shimmer
 /// BalanceView()
-///   .ironShimmer(active: isLoading)
+///   .ironShimmer(isActive: isLoading)
 /// ```
 ///
 /// ## Stealth Mode Style
@@ -32,15 +32,15 @@ public struct IronShimmerModifier: ViewModifier {
   /// Creates a shimmer modifier.
   ///
   /// - Parameters:
-  ///   - active: Whether the shimmer is animating.
+  ///   - isActive: Whether the shimmer is animating.
   ///   - style: The shimmer visual style.
   ///   - duration: Duration of one shimmer cycle.
   public init(
-    active: Bool = true,
+    isActive: Bool = true,
     style: IronShimmerStyle = .standard,
     duration: Double = 1.5,
   ) {
-    self.active = active
+    self.isActive = isActive
     self.style = style
     self.duration = duration
   }
@@ -50,7 +50,7 @@ public struct IronShimmerModifier: ViewModifier {
   public func body(content: Content) -> some View {
     content
       .overlay {
-        if active {
+        if isActive {
           GeometryReader { geometry in
             shimmerGradient
               .frame(width: geometry.size.width * 2)
@@ -61,10 +61,10 @@ public struct IronShimmerModifier: ViewModifier {
         }
       }
       .onAppear {
-        guard active else { return }
+        guard isActive else { return }
         startAnimation()
       }
-      .onChange(of: active) { _, newValue in
+      .onChange(of: isActive) { _, newValue in
         if newValue {
           startAnimation()
         }
@@ -75,7 +75,7 @@ public struct IronShimmerModifier: ViewModifier {
 
   @State private var animating = false
 
-  private let active: Bool
+  private let isActive: Bool
   private let style: IronShimmerStyle
   private let duration: Double
 
@@ -153,7 +153,7 @@ extension View {
   /// ```swift
   /// // Loading shimmer
   /// PlaceholderCard()
-  ///   .ironShimmer(active: isLoading)
+  ///   .ironShimmer(isActive: isLoading)
   ///
   /// // Stealth mode
   /// Text("$••••")
@@ -161,18 +161,18 @@ extension View {
   /// ```
   ///
   /// - Parameters:
-  ///   - active: Whether shimmer is animating.
+  ///   - isActive: Whether shimmer is animating.
   ///   - style: The shimmer visual style.
   ///   - duration: Duration of one cycle.
   /// - Returns: A view with shimmer effect.
   public func ironShimmer(
-    active: Bool = true,
+    isActive: Bool = true,
     style: IronShimmerStyle = .standard,
     duration: Double = 1.5,
   ) -> some View {
     modifier(
       IronShimmerModifier(
-        active: active,
+        isActive: isActive,
         style: style,
         duration: duration,
       )
@@ -352,7 +352,7 @@ public struct IronShimmerView: View {
       .frame(maxWidth: .infinity)
       .background(Color.green.opacity(0.2))
       .clipShape(RoundedRectangle(cornerRadius: 12))
-      .ironShimmer(active: isLoading)
+      .ironShimmer(isActive: isLoading)
   }
   .padding()
 }

--- a/Sources/IronCore/Logging/IronLogger.swift
+++ b/Sources/IronCore/Logging/IronLogger.swift
@@ -292,26 +292,26 @@ public struct IronPrintHandler: IronLogHandler {
   /// - Parameters:
   ///   - label: A label to prefix log messages with.
   ///   - minimumLevel: The minimum level to log.
-  ///   - includeTimestamp: Whether to include timestamps in output.
-  ///   - includeSource: Whether to include source file/line information.
+  ///   - isTimestampIncluded: Whether to include timestamps in output.
+  ///   - isSourceIncluded: Whether to include source file/line information.
   public init(
     label: String,
     minimumLevel: IronLogLevel = .debug,
-    includeTimestamp: Bool = true,
-    includeSource: Bool = true,
+    isTimestampIncluded: Bool = true,
+    isSourceIncluded: Bool = true,
   ) {
     self.label = label
     self.minimumLevel = minimumLevel
-    self.includeTimestamp = includeTimestamp
-    self.includeSource = includeSource
+    self.isTimestampIncluded = isTimestampIncluded
+    self.isSourceIncluded = isSourceIncluded
   }
 
   // MARK: Public
 
   public let label: String
   public let minimumLevel: IronLogLevel
-  public let includeTimestamp: Bool
-  public let includeSource: Bool
+  public let isTimestampIncluded: Bool
+  public let isSourceIncluded: Bool
 
   public func log(
     level: IronLogLevel,
@@ -326,7 +326,7 @@ public struct IronPrintHandler: IronLogHandler {
 
     var components = [String]()
 
-    if includeTimestamp {
+    if isTimestampIncluded {
       components.append(Self.timestampFormatter.string(from: Date()))
     }
 
@@ -334,7 +334,7 @@ public struct IronPrintHandler: IronLogHandler {
     components.append(level.emoji)
     components.append(level.label)
 
-    if includeSource {
+    if isSourceIncluded {
       let fileName = (file as NSString).lastPathComponent
       components.append("(\(fileName):\(line))")
     }

--- a/Sources/IronNavigation/Tray/IronTray.swift
+++ b/Sources/IronNavigation/Tray/IronTray.swift
@@ -44,15 +44,15 @@ public struct IronTray<Content: View>: View {
   /// Creates a content-sized tray.
   ///
   /// - Parameters:
-  ///   - showsDragIndicator: Whether to show the drag handle.
+  ///   - isDragIndicatorVisible: Whether to show the drag handle.
   ///   - onDismiss: Called when the tray is dismissed.
   ///   - content: The tray content - height is determined by this content.
   public init(
-    showsDragIndicator: Bool = true,
+    isDragIndicatorVisible: Bool = true,
     onDismiss: (() -> Void)? = nil,
     @ViewBuilder content: () -> Content,
   ) {
-    self.showsDragIndicator = showsDragIndicator
+    self.isDragIndicatorVisible = isDragIndicatorVisible
     self.onDismiss = onDismiss
     self.content = content()
   }
@@ -74,7 +74,7 @@ public struct IronTray<Content: View>: View {
         // Tray card
         VStack(spacing: 0) {
           // Drag indicator
-          if showsDragIndicator {
+          if isDragIndicatorVisible {
             dragIndicator
           }
 
@@ -116,7 +116,7 @@ public struct IronTray<Content: View>: View {
   @State private var isVisible = false
   @State private var dragOffset: CGFloat = 0
 
-  private let showsDragIndicator: Bool
+  private let isDragIndicatorVisible: Bool
   private let onDismiss: (() -> Void)?
   private let content: Content
 
@@ -196,15 +196,15 @@ public struct IronTrayHeader: View {
   ///
   /// - Parameters:
   ///   - title: The header title.
-  ///   - showsBackButton: If true, shows back arrow instead of close.
+  ///   - isBackButtonVisible: If true, shows back arrow instead of close.
   ///   - onDismiss: Action when the button is tapped.
   public init(
     _ title: LocalizedStringKey,
-    showsBackButton: Bool = false,
+    isBackButtonVisible: Bool = false,
     onDismiss: @escaping () -> Void,
   ) {
     self.title = title
-    self.showsBackButton = showsBackButton
+    self.isBackButtonVisible = isBackButtonVisible
     self.onDismiss = onDismiss
   }
 
@@ -215,12 +215,12 @@ public struct IronTrayHeader: View {
       Button {
         IronLogger.ui.debug(
           "IronTrayHeader tapped",
-          metadata: ["isBack": .string("\(showsBackButton)")],
+          metadata: ["isBack": .string("\(isBackButtonVisible)")],
         )
         onDismiss()
       } label: {
         IronIcon(
-          systemName: showsBackButton ? "chevron.left" : "xmark",
+          systemName: isBackButtonVisible ? "chevron.left" : "xmark",
           size: .small,
           color: .secondary,
         )
@@ -232,7 +232,7 @@ public struct IronTrayHeader: View {
         }
       }
       .buttonStyle(.plain)
-      .accessibilityLabel(showsBackButton ? "Back" : "Close")
+      .accessibilityLabel(isBackButtonVisible ? "Back" : "Close")
 
       Spacer()
 
@@ -253,7 +253,7 @@ public struct IronTrayHeader: View {
   @Environment(\.ironTheme) private var theme
 
   private let title: LocalizedStringKey
-  private let showsBackButton: Bool
+  private let isBackButtonVisible: Bool
   private let onDismiss: () -> Void
 }
 
@@ -514,7 +514,7 @@ public struct IronTrayNavigator {
               navigator.push {
                 // Step 2 - taller
                 VStack(spacing: 16) {
-                  IronTrayHeader("Step 2", showsBackButton: true, onDismiss: { navigator.pop() })
+                  IronTrayHeader("Step 2", isBackButtonVisible: true, onDismiss: { navigator.pop() })
 
                   Text("Notice the height change!")
                     .padding(.horizontal)

--- a/Sources/IronNavigation/Tray/IronTrayModifier.swift
+++ b/Sources/IronNavigation/Tray/IronTrayModifier.swift
@@ -10,12 +10,12 @@ struct IronTrayModifier<TrayContent: View>: ViewModifier {
 
   init(
     isPresented: Binding<Bool>,
-    showsDragIndicator: Bool,
+    isDragIndicatorVisible: Bool,
     onDismiss: (() -> Void)?,
     @ViewBuilder content: () -> TrayContent,
   ) {
     _isPresented = isPresented
-    self.showsDragIndicator = showsDragIndicator
+    self.isDragIndicatorVisible = isDragIndicatorVisible
     self.onDismiss = onDismiss
     trayContent = content()
   }
@@ -27,7 +27,7 @@ struct IronTrayModifier<TrayContent: View>: ViewModifier {
       .overlay {
         if isPresented {
           IronTray(
-            showsDragIndicator: showsDragIndicator,
+            isDragIndicatorVisible: isDragIndicatorVisible,
             onDismiss: {
               isPresented = false
               onDismiss?()
@@ -48,7 +48,7 @@ struct IronTrayModifier<TrayContent: View>: ViewModifier {
 
   @Binding private var isPresented: Bool
 
-  private let showsDragIndicator: Bool
+  private let isDragIndicatorVisible: Bool
   private let onDismiss: (() -> Void)?
   private let trayContent: TrayContent
 
@@ -79,20 +79,20 @@ extension View {
   ///
   /// - Parameters:
   ///   - isPresented: Binding controlling tray visibility.
-  ///   - showsDragIndicator: Whether to show the drag handle. Defaults to `true`.
+  ///   - isDragIndicatorVisible: Whether to show the drag handle. Defaults to `true`.
   ///   - onDismiss: Called when the tray is dismissed.
   ///   - content: The tray content builder.
   /// - Returns: A view with tray presentation capability.
   public func ironTray(
     isPresented: Binding<Bool>,
-    showsDragIndicator: Bool = true,
+    isDragIndicatorVisible: Bool = true,
     onDismiss: (() -> Void)? = nil,
     @ViewBuilder content: () -> some View,
   ) -> some View {
     modifier(
       IronTrayModifier(
         isPresented: isPresented,
-        showsDragIndicator: showsDragIndicator,
+        isDragIndicatorVisible: isDragIndicatorVisible,
         onDismiss: onDismiss,
         content: content,
       )

--- a/Sources/IronPrimitives/Button/IronButton.swift
+++ b/Sources/IronPrimitives/Button/IronButton.swift
@@ -55,19 +55,19 @@ public struct IronButton<Label: View>: View {
   ///   - variant: The visual style of the button.
   ///   - size: The size of the button.
   ///   - isFullWidth: Whether the button should expand to fill available width.
-  ///   - action: The action to perform when the button is tapped.
+  ///   - onTap: The action to perform when the button is tapped.
   ///   - label: A view builder that creates the button's label.
   public init(
     variant: IronButtonVariant = .filled,
     size: IronButtonSize = .medium,
     isFullWidth: Bool = false,
-    action: @escaping () -> Void,
+    onTap: @escaping () -> Void,
     @ViewBuilder label: () -> Label,
   ) {
     self.variant = variant
     self.size = size
     self.isFullWidth = isFullWidth
-    self.action = action
+    self.onTap = onTap
     self.label = label()
   }
 
@@ -76,7 +76,7 @@ public struct IronButton<Label: View>: View {
   public var body: some View {
     Button {
       IronLogger.ui.debug("IronButton tapped", metadata: ["variant": .string("\(variant)"), "size": .string("\(size)")])
-      action()
+      onTap()
     } label: {
       label
         .contentTransition(.interpolate)
@@ -100,7 +100,7 @@ public struct IronButton<Label: View>: View {
   private let variant: IronButtonVariant
   private let size: IronButtonSize
   private let isFullWidth: Bool
-  private let action: () -> Void
+  private let onTap: () -> Void
   private let label: Label
 
 }
@@ -115,18 +115,18 @@ extension IronButton where Label == IronText {
   ///   - variant: The visual style of the button.
   ///   - size: The size of the button.
   ///   - isFullWidth: Whether the button should expand to fill available width.
-  ///   - action: The action to perform when the button is tapped.
+  ///   - onTap: The action to perform when the button is tapped.
   public init(
     _ title: LocalizedStringKey,
     variant: IronButtonVariant = .filled,
     size: IronButtonSize = .medium,
     isFullWidth: Bool = false,
-    action: @escaping () -> Void,
+    onTap: @escaping () -> Void,
   ) {
     self.variant = variant
     self.size = size
     self.isFullWidth = isFullWidth
-    self.action = action
+    self.onTap = onTap
     label = IronText(title, style: .labelLarge, color: .inherited)
   }
 
@@ -137,18 +137,18 @@ extension IronButton where Label == IronText {
   ///   - variant: The visual style of the button.
   ///   - size: The size of the button.
   ///   - isFullWidth: Whether the button should expand to fill available width.
-  ///   - action: The action to perform when the button is tapped.
+  ///   - onTap: The action to perform when the button is tapped.
   public init(
     _ title: some StringProtocol,
     variant: IronButtonVariant = .filled,
     size: IronButtonSize = .medium,
     isFullWidth: Bool = false,
-    action: @escaping () -> Void,
+    onTap: @escaping () -> Void,
   ) {
     self.variant = variant
     self.size = size
     self.isFullWidth = isFullWidth
-    self.action = action
+    self.onTap = onTap
     label = IronText(title, style: .labelLarge, color: .inherited)
   }
 }

--- a/Sources/IronPrimitives/Card/IronCard.swift
+++ b/Sources/IronPrimitives/Card/IronCard.swift
@@ -32,10 +32,10 @@ import SwiftUI
 /// ## Tappable Cards
 ///
 /// ```swift
-/// IronCard {
-///   Text("Tap me")
-/// } action: {
+/// IronCard(onTap: {
 ///   print("Card tapped")
+/// }) {
+///   Text("Tap me")
 /// }
 /// ```
 ///
@@ -70,7 +70,7 @@ public struct IronCard<Content: View, Header: View, Footer: View>: View {
     self.content = content()
     header = nil
     footer = nil
-    action = nil
+    onTap = nil
   }
 
   /// Creates a tappable card with content.
@@ -78,20 +78,20 @@ public struct IronCard<Content: View, Header: View, Footer: View>: View {
   /// - Parameters:
   ///   - style: The visual style of the card.
   ///   - padding: The padding inside the card.
+  ///   - onTap: The action to perform when tapped.
   ///   - content: The main content of the card.
-  ///   - action: The action to perform when tapped.
   public init(
     style: IronCardStyle = .elevated,
     padding: IronCardPadding = .standard,
+    onTap: @escaping () -> Void,
     @ViewBuilder content: () -> Content,
-    action: @escaping () -> Void,
   ) where Header == EmptyView, Footer == EmptyView {
     self.style = style
     self.padding = padding
+    self.onTap = onTap
     self.content = content()
     header = nil
     footer = nil
-    self.action = action
   }
 
   /// Creates a card with header, content, and footer.
@@ -114,7 +114,7 @@ public struct IronCard<Content: View, Header: View, Footer: View>: View {
     self.content = content()
     self.header = header()
     self.footer = footer()
-    action = nil
+    onTap = nil
   }
 
   /// Creates a card with header and content.
@@ -135,7 +135,7 @@ public struct IronCard<Content: View, Header: View, Footer: View>: View {
     self.content = content()
     self.header = header()
     footer = nil
-    action = nil
+    onTap = nil
   }
 
   /// Creates a card with content and footer.
@@ -156,17 +156,17 @@ public struct IronCard<Content: View, Header: View, Footer: View>: View {
     self.content = content()
     header = nil
     self.footer = footer()
-    action = nil
+    onTap = nil
   }
 
   // MARK: Public
 
   public var body: some View {
     Group {
-      if let action {
+      if let onTap {
         Button {
           IronLogger.ui.debug("IronCard tapped", metadata: ["style": .string("\(style)")])
-          action()
+          onTap()
         } label: {
           cardContent
         }
@@ -200,7 +200,7 @@ public struct IronCard<Content: View, Header: View, Footer: View>: View {
   private let content: Content
   private let header: Header?
   private let footer: Footer?
-  private let action: (() -> Void)?
+  private let onTap: (() -> Void)?
 
   private var cardShape: some InsettableShape {
     RoundedRectangle(cornerRadius: theme.radii.lg, style: .continuous)
@@ -478,7 +478,9 @@ public enum IronCardPadding: Sendable, CaseIterable {
 
 #Preview("IronCard - Tappable") {
   VStack(spacing: 16) {
-    IronCard {
+    IronCard(onTap: {
+      // Handle tap
+    }) {
       HStack {
         Image(systemName: "gear")
           .font(.title2)
@@ -494,11 +496,11 @@ public enum IronCardPadding: Sendable, CaseIterable {
         Image(systemName: "chevron.right")
           .foregroundStyle(.secondary)
       }
-    } action: {
-      // Handle tap
     }
 
-    IronCard(style: .outlined) {
+    IronCard(style: .outlined, onTap: {
+      // Handle tap
+    }) {
       HStack {
         Image(systemName: "bell")
           .font(.title2)
@@ -514,8 +516,6 @@ public enum IronCardPadding: Sendable, CaseIterable {
         Image(systemName: "chevron.right")
           .foregroundStyle(.secondary)
       }
-    } action: {
-      // Handle tap
     }
   }
   .padding()
@@ -525,7 +525,9 @@ public enum IronCardPadding: Sendable, CaseIterable {
   ScrollView {
     VStack(spacing: 12) {
       ForEach(0..<5) { index in
-        IronCard {
+        IronCard(onTap: {
+          // Handle tap
+        }) {
           HStack {
             Circle()
               .fill(Color.blue.opacity(0.2))
@@ -543,8 +545,6 @@ public enum IronCardPadding: Sendable, CaseIterable {
             }
             Spacer()
           }
-        } action: {
-          // Handle tap
         }
       }
     }

--- a/Sources/IronPrimitives/SecureField/IronSecureField.swift
+++ b/Sources/IronPrimitives/SecureField/IronSecureField.swift
@@ -19,7 +19,7 @@ import SwiftUI
 /// ## With Visibility Toggle
 ///
 /// ```swift
-/// IronSecureField("Password", text: $password, showToggle: true)
+/// IronSecureField("Password", text: $password, isToggleVisible: true)
 /// ```
 ///
 /// ## Styles
@@ -56,21 +56,21 @@ public struct IronSecureField<Leading: View>: View {
   ///   - style: The visual style of the field.
   ///   - size: The size of the field.
   ///   - state: The validation state.
-  ///   - showToggle: Whether to show the visibility toggle.
+  ///   - isToggleVisible: Whether to show the visibility toggle.
   public init(
     _ placeholder: LocalizedStringKey,
     text: Binding<String>,
     style: IronTextFieldStyle = .outlined,
     size: IronTextFieldSize = .medium,
     state: IronTextFieldState = .normal,
-    showToggle: Bool = true,
+    isToggleVisible: Bool = true,
   ) where Leading == EmptyView {
     self.placeholder = placeholder
     _text = text
     self.style = style
     self.size = size
     self.state = state
-    self.showToggle = showToggle
+    self.isToggleVisible = isToggleVisible
     leading = nil
   }
 
@@ -82,21 +82,21 @@ public struct IronSecureField<Leading: View>: View {
   ///   - style: The visual style of the field.
   ///   - size: The size of the field.
   ///   - state: The validation state.
-  ///   - showToggle: Whether to show the visibility toggle.
+  ///   - isToggleVisible: Whether to show the visibility toggle.
   public init(
     _ placeholder: some StringProtocol,
     text: Binding<String>,
     style: IronTextFieldStyle = .outlined,
     size: IronTextFieldSize = .medium,
     state: IronTextFieldState = .normal,
-    showToggle: Bool = true,
+    isToggleVisible: Bool = true,
   ) where Leading == EmptyView {
     self.placeholder = LocalizedStringKey(String(placeholder))
     _text = text
     self.style = style
     self.size = size
     self.state = state
-    self.showToggle = showToggle
+    self.isToggleVisible = isToggleVisible
     leading = nil
   }
 
@@ -108,7 +108,7 @@ public struct IronSecureField<Leading: View>: View {
   ///   - style: The visual style of the field.
   ///   - size: The size of the field.
   ///   - state: The validation state.
-  ///   - showToggle: Whether to show the visibility toggle.
+  ///   - isToggleVisible: Whether to show the visibility toggle.
   ///   - leading: The leading accessory view.
   public init(
     _ placeholder: LocalizedStringKey,
@@ -116,7 +116,7 @@ public struct IronSecureField<Leading: View>: View {
     style: IronTextFieldStyle = .outlined,
     size: IronTextFieldSize = .medium,
     state: IronTextFieldState = .normal,
-    showToggle: Bool = true,
+    isToggleVisible: Bool = true,
     @ViewBuilder leading: () -> Leading,
   ) {
     self.placeholder = placeholder
@@ -124,7 +124,7 @@ public struct IronSecureField<Leading: View>: View {
     self.style = style
     self.size = size
     self.state = state
-    self.showToggle = showToggle
+    self.isToggleVisible = isToggleVisible
     self.leading = leading()
   }
 
@@ -159,7 +159,7 @@ public struct IronSecureField<Leading: View>: View {
   private let style: IronTextFieldStyle
   private let size: IronTextFieldSize
   private let state: IronTextFieldState
-  private let showToggle: Bool
+  private let isToggleVisible: Bool
   private let leading: Leading?
 
   private var fieldContainer: some View {
@@ -187,7 +187,7 @@ public struct IronSecureField<Leading: View>: View {
         )
       }
 
-      if showToggle {
+      if isToggleVisible {
         Button {
           withAnimation(theme.animation.snappy) {
             isRevealed.toggle()
@@ -418,8 +418,8 @@ public struct IronSecureField<Leading: View>: View {
   @Previewable @State var password = ""
 
   return VStack(spacing: 16) {
-    IronSecureField("With toggle", text: $password, showToggle: true)
-    IronSecureField("Without toggle", text: $password, showToggle: false)
+    IronSecureField("With toggle", text: $password, isToggleVisible: true)
+    IronSecureField("Without toggle", text: $password, isToggleVisible: false)
   }
   .padding()
 }

--- a/Tests/IronComponentsTests/IronComponentsTests.swift
+++ b/Tests/IronComponentsTests/IronComponentsTests.swift
@@ -365,7 +365,7 @@ struct IronSkeletonTests {
 
   @Test("can be created without animation")
   func createWithoutAnimation() {
-    _ = IronSkeleton(shape: .text(), animated: false)
+    _ = IronSkeleton(shape: .text(), isAnimated: false)
     // Skeleton created successfully
   }
 }
@@ -421,13 +421,13 @@ struct IronSkeletonCardTests {
 
   @Test("can be created with image placeholder")
   func createWithImagePlaceholder() {
-    _ = IronSkeletonCard(showImage: true)
+    _ = IronSkeletonCard(isImageVisible: true)
     // SkeletonCard created successfully
   }
 
   @Test("can be created without image placeholder")
   func createWithoutImagePlaceholder() {
-    _ = IronSkeletonCard(showImage: false)
+    _ = IronSkeletonCard(isImageVisible: false)
     // SkeletonCard created successfully
   }
 }

--- a/Tests/IronPrimitivesTests/IronPrimitivesTests.swift
+++ b/Tests/IronPrimitivesTests/IronPrimitivesTests.swift
@@ -631,10 +631,10 @@ struct IronCardTests {
 
   @Test("can be created as tappable")
   func createAsTappable() {
-    _ = IronCard {
-      Text("Tappable card")
-    } action: {
+    _ = IronCard(onTap: {
       // Action
+    }) {
+      Text("Tappable card")
     }
     // Tappable card created successfully
   }
@@ -1105,13 +1105,13 @@ struct IronSecureFieldTests {
 
   @Test("supports show toggle")
   func supportsShowToggle() {
-    _ = IronSecureField("Password", text: .constant(""), showToggle: true)
+    _ = IronSecureField("Password", text: .constant(""), isToggleVisible: true)
     // Show toggle works
   }
 
   @Test("supports hiding toggle")
   func supportsHidingToggle() {
-    _ = IronSecureField("Password", text: .constant(""), showToggle: false)
+    _ = IronSecureField("Password", text: .constant(""), isToggleVisible: false)
     // Hidden toggle works
   }
 
@@ -1131,7 +1131,7 @@ struct IronSecureFieldTests {
       style: .outlined,
       size: .large,
       state: .success,
-      showToggle: true,
+      isToggleVisible: true,
       leading: {
         Image(systemName: "lock")
       },

--- a/Tests/IronUISnapshotTests/Components/IronComponentsSnapshotTests.swift
+++ b/Tests/IronUISnapshotTests/Components/IronComponentsSnapshotTests.swift
@@ -295,16 +295,16 @@ struct IronSkeletonSnapshotTests {
   @MainActor
   func skeletonShapes() {
     let view = VStack(spacing: 24) {
-      IronSkeleton(shape: .text(), animated: false)
+      IronSkeleton(shape: .text(), isAnimated: false)
         .frame(width: 200)
 
-      IronSkeleton(shape: .circle(size: 48), animated: false)
+      IronSkeleton(shape: .circle(size: 48), isAnimated: false)
 
-      IronSkeleton(shape: .rectangle(width: 150, height: 100), animated: false)
+      IronSkeleton(shape: .rectangle(width: 150, height: 100), isAnimated: false)
 
-      IronSkeleton(shape: .rounded(width: 120, height: 40, radius: 8), animated: false)
+      IronSkeleton(shape: .rounded(width: 120, height: 40, radius: 8), isAnimated: false)
 
-      IronSkeleton(shape: .capsule(width: 100, height: 32), animated: false)
+      IronSkeleton(shape: .capsule(width: 100, height: 32), isAnimated: false)
     }
     .padding()
 

--- a/Tests/IronUISnapshotTests/Navigation/IronNavigationSnapshotTests.swift
+++ b/Tests/IronUISnapshotTests/Navigation/IronNavigationSnapshotTests.swift
@@ -22,7 +22,7 @@ struct IronTrayHeaderSnapshotTests {
   @Test("TrayHeader - Back Button")
   @MainActor
   func trayHeaderBackButton() {
-    let view = IronTrayHeader("Profile Details", showsBackButton: true) { }
+    let view = IronTrayHeader("Profile Details", isBackButtonVisible: true) { }
       .padding()
       .background(Color.gray.opacity(0.1))
 
@@ -43,7 +43,7 @@ struct IronTrayHeaderSnapshotTests {
 
       VStack(alignment: .leading, spacing: 4) {
         IronText("Nested Level (Back)", style: .caption, color: .secondary)
-        IronTrayHeader("Step 2", showsBackButton: true) { }
+        IronTrayHeader("Step 2", isBackButtonVisible: true) { }
           .background(Color.gray.opacity(0.1))
       }
     }
@@ -105,7 +105,7 @@ struct IronTraySnapshotTests {
         .padding(.bottom, 4)
 
       VStack(spacing: 16) {
-        IronTrayHeader("Choose Option", showsBackButton: true) { }
+        IronTrayHeader("Choose Option", isBackButtonVisible: true) { }
 
         ForEach(["Option A", "Option B", "Option C"], id: \.self) { option in
           HStack {


### PR DESCRIPTION
## Summary

Updates component APIs to follow ADR-0006 naming conventions for parameters and callbacks.

### Changes

**Action Callbacks (Issue #53, #55)**
- `action` → `onTap` in IronButton, IronMenuItem, IronCard
- `haptic` → `onTrigger` in IronHaptics

**Boolean Properties (Issues #52, #54, #57)**
- `showToggle` → `isToggleVisible` (IronSecureField)
- `showImage` → `isImageVisible` (IronSkeletonCard)
- `animated` → `isAnimated` (IronSkeleton)
- `active` → `isActive` (IronShimmer, IronShake, IronWiggle, IronBounce)
- `trigger` → `isTriggered` (IronHaptics)
- `showsDragIndicator` → `isDragIndicatorVisible` (IronTray)
- `showsBackButton` → `isBackButtonVisible` (IronTrayHeader)
- `includeTimestamp` → `isTimestampIncluded` (IronPrintHandler)
- `includeSource` → `isSourceIncluded` (IronPrintHandler)

**Parameter Order (Issue #56)**
- IronCard tappable initializer: `onTap` now comes before `@ViewBuilder content`

## Test plan

- [x] Build succeeds
- [x] All unit tests pass
- [x] Snapshot test failures are pre-existing (unrelated to this change)

Closes #52, #53, #54, #55, #56, #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)