### PR TITLE
fix: remove unused IronFormFieldStyle enum

### DIFF
--- a/Sources/IronForms/FormField/IronFormField.swift
+++ b/Sources/IronForms/FormField/IronFormField.swift
@@ -138,18 +138,6 @@ public struct IronFormField<Content: View>: View {
   }
 }
 
-// MARK: - IronFormFieldStyle
-
-/// Styles for form field layout.
-public enum IronFormFieldStyle: Sendable {
-  /// Stacked layout with label above input.
-  case stacked
-  /// Horizontal layout with label beside input.
-  case horizontal
-  /// Floating label that animates into the field.
-  case floating
-}
-
 // MARK: - Previews
 
 #Preview("IronFormField - Basic") {


### PR DESCRIPTION
## Summary
- Removes the unused `IronFormFieldStyle` enum from `IronFormField.swift`
- The enum was defined but never used in any initializer or component logic
- Cleans up the public API by removing dead code

Closes #42

## Test plan
- [x] Build passes (`swift run ironui-cli build`)
- [x] No references to `IronFormFieldStyle` in the codebase (it was unused)