### PR TITLE
fix: apply widthRatio parameter in IronSkeleton .text shape

### DIFF
--- a/Sources/IronComponents/Skeleton/IronSkeleton.swift
+++ b/Sources/IronComponents/Skeleton/IronSkeleton.swift
@@ -78,11 +78,14 @@ public struct IronSkeleton: View {
   private var skeletonContent: some View {
     switch shape {
     case .text(let widthRatio):
-      skeletonView(
-        shape: RoundedRectangle(cornerRadius: 4),
-        width: widthRatio < 1.0 ? nil : nil,
-        height: 16,
-      )
+      GeometryReader { geometry in
+        skeletonView(
+          shape: RoundedRectangle(cornerRadius: 4),
+          width: widthRatio < 1.0 ? geometry.size.width * widthRatio : nil,
+          height: 16,
+        )
+      }
+      .frame(height: 16)
 
     case .circle(let size):
       skeletonView(


### PR DESCRIPTION
## Summary

- Fix bug where `IronSkeleton`'s `.text(widthRatio:)` shape case ignored the `widthRatio` parameter
- Use `GeometryReader` to calculate proportional width when `widthRatio < 1.0`
- When `widthRatio >= 1.0`, skeleton fills available width (existing behavior)

## Test plan

- [ ] Verify `.text(widthRatio: 0.7)` renders at 70% of container width
- [ ] Verify `.text()` (default `widthRatio: 1.0`) still fills container width
- [ ] Run snapshot tests to check for regressions

Fixes #41