### PR TITLE
fix: respect Reduce Motion in IronFormField animation

### DIFF
--- a/Sources/IronForms/FormField/IronFormField.swift
+++ b/Sources/IronForms/FormField/IronFormField.swift
@@ -114,7 +114,7 @@ public struct IronFormField<Content: View>: View {
         IronText(hint, style: .caption, color: .secondary)
       }
     }
-    .animation(.easeInOut(duration: 0.2), value: error)
+    .accessibleAnimation(theme.animation.snappy, value: error)
     .accessibilityElement(children: .contain)
   }
 


### PR DESCRIPTION
## Summary
- Replace hard-coded animation with `accessibleAnimation` modifier in `IronFormField`
- Animation now disabled when Reduce Motion is enabled or `ironSkipEntranceAnimations` is set
- Uses theme animation tokens (`theme.animation.snappy`) instead of hard-coded duration

Fixes #51

## Test plan
- [ ] Verify hint/error animation works normally without Reduce Motion
- [ ] Enable Reduce Motion in System Settings and verify animation is disabled
- [ ] Set `ironSkipEntranceAnimations` environment and verify animation is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)