### PR TITLE
fix: replace raw SwiftUI primitives with IronUI primitives

### DIFF
--- a/Sources/IronComponents/Menu/IronMenu.swift
+++ b/Sources/IronComponents/Menu/IronMenu.swift
@@ -282,7 +282,7 @@ public struct IronMenuSection<Content: View>: View {
     Section {
       content
     } header: {
-      Text(header)
+      IronText(header, style: .labelSmall, color: .secondary)
     }
   }
 
@@ -342,7 +342,7 @@ public struct IronMenuPicker<Option: Hashable, Label: View>: View {
             labelBuilder(option)
             Spacer()
             if option == selection {
-              Image(systemName: "checkmark")
+              IronIcon(systemName: "checkmark", size: .xSmall, color: .primary)
             }
           }
         }

--- a/Sources/IronDataDisplay/Database/Cells/IronDatabaseCells.swift
+++ b/Sources/IronDataDisplay/Database/Cells/IronDatabaseCells.swift
@@ -331,8 +331,10 @@ struct IronSelectCell: View {
   var body: some View {
     if isEditing {
       Menu {
-        Button("Clear") {
+        Button {
           value = nil
+        } label: {
+          IronText("Clear", style: .bodyMedium, color: .primary)
         }
         Divider()
         ForEach(options) { option in
@@ -343,9 +345,9 @@ struct IronSelectCell: View {
               Circle()
                 .fill(colorForOption(option))
                 .frame(width: 8, height: 8)
-              Text(option.name)
+              IronText(option.name, style: .bodyMedium, color: .primary)
               if value == option.id {
-                Image(systemName: "checkmark")
+                IronIcon(systemName: "checkmark", size: .xSmall, color: .primary)
               }
             }
           }
@@ -426,9 +428,9 @@ struct IronMultiSelectCell: View {
               Circle()
                 .fill(colorForOption(option))
                 .frame(width: 8, height: 8)
-              Text(option.name)
+              IronText(option.name, style: .bodyMedium, color: .primary)
               if value.contains(option.id) {
-                Image(systemName: "checkmark")
+                IronIcon(systemName: "checkmark", size: .xSmall, color: .primary)
               }
             }
           }


### PR DESCRIPTION
## Summary

- Replace raw `Text` and `Image` with `IronText` and `IronIcon` in non-preview component code
- Ensures consistent theming, typography, and accessibility patterns across IronUI

### Changes
- **IronMenuSection**: Use `IronText` for section headers
- **IronMenuPicker**: Use `IronIcon` for checkmark indicator
- **IronSelectCell**: Use `IronText` for option labels and `IronIcon` for checkmarks
- **IronMultiSelectCell**: Use `IronText` for option labels and `IronIcon` for checkmarks

Note: `IronAlert.swift` (mentioned in #18) already uses IronUI primitives correctly. The raw `Text` usage is appropriate for accessibility labels, and preview code is allowed to use raw SwiftUI views.

Closes #18
Closes #45

## Test plan

- [ ] Verify IronMenu previews render correctly
- [ ] Verify IronMenuPicker shows checkmark for selected item
- [ ] Verify IronSelectCell and IronMultiSelectCell show styled labels and checkmarks
- [ ] Confirm no visual regressions in menu components

🤖 Generated with [Claude Code](https://claude.com/claude-code)