### PR TITLE
fix: guard IronSegmentedControl against empty options

### DIFF
--- a/Sources/IronComponents/SegmentedControl/IronSegmentedControl.swift
+++ b/Sources/IronComponents/SegmentedControl/IronSegmentedControl.swift
@@ -69,6 +69,27 @@ public struct IronSegmentedControl<Option: Hashable, Label: View>: View {
   // MARK: Public
 
   public var body: some View {
+    if options.isEmpty {
+      EmptyView()
+    } else {
+      bodyContent
+    }
+  }
+
+  // MARK: Private
+
+  @Environment(\.ironTheme) private var theme
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @Environment(\.ironSkipEntranceAnimations) private var skipEntranceAnimations
+  @Namespace private var namespace
+
+  @Binding private var selection: Option
+
+  private let options: [Option]
+  private let size: IronSegmentedControlSize
+  private let labelBuilder: (Option) -> Label
+
+  private var bodyContent: some View {
     GeometryReader { geometry in
       let segmentWidth = geometry.size.width / CGFloat(options.count)
 
@@ -123,19 +144,6 @@ public struct IronSegmentedControl<Option: Hashable, Label: View>: View {
     .accessibilityElement(children: .contain)
     .accessibilityLabel("Segmented control")
   }
-
-  // MARK: Private
-
-  @Environment(\.ironTheme) private var theme
-  @Environment(\.accessibilityReduceMotion) private var reduceMotion
-  @Environment(\.ironSkipEntranceAnimations) private var skipEntranceAnimations
-  @Namespace private var namespace
-
-  @Binding private var selection: Option
-
-  private let options: [Option]
-  private let size: IronSegmentedControlSize
-  private let labelBuilder: (Option) -> Label
 
   private var selectedIndex: CGFloat {
     guard let index = options.firstIndex(of: selection) else { return 0 }

--- a/Tests/IronComponentsTests/IronComponentsTests.swift
+++ b/Tests/IronComponentsTests/IronComponentsTests.swift
@@ -530,6 +530,18 @@ struct IronSegmentedControlTests {
     // SegmentedControl created successfully with custom label
   }
 
+  @Test("handles empty options gracefully")
+  func handlesEmptyOptions() {
+    // Empty options should not crash (previously caused divide-by-zero)
+    _ = IronSegmentedControl(
+      selection: .constant(TestOption.first),
+      options: [],
+    ) { option in
+      Text(option.rawValue)
+    }
+    // SegmentedControl created successfully with empty options
+  }
+
   // MARK: Private
 
   private enum TestOption: String, CaseIterable, CustomStringConvertible {


### PR DESCRIPTION
## Summary

- Guard `options.isEmpty` in body and return `EmptyView()` to prevent divide-by-zero in `segmentWidth` calculation
- Add unit test for empty options behavior

Closes #69

## Test plan

- [x] New unit test `handles empty options gracefully` passes
- [x] All existing `IronSegmentedControl` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)