### PR TITLE
fix: remove legacy platform fallback in Color(light:dark:)

### DIFF
--- a/Sources/IronCore/Theming/Tokens/IronColorTokens.swift
+++ b/Sources/IronCore/Theming/Tokens/IronColorTokens.swift
@@ -361,8 +361,6 @@ extension Color {
       }
     }
     self.init(nsColor: nsColor)
-    #else
-    self = light
     #endif
   }
 }

--- a/Sources/IronCore/Theming/Tokens/IronShadowTokens.swift
+++ b/Sources/IronCore/Theming/Tokens/IronShadowTokens.swift
@@ -115,7 +115,7 @@ public struct IronShadowModifier: ViewModifier {
             color: layer.color,
             radius: layer.radius,
             x: layer.x,
-            y: layer.y
+            y: layer.y,
           )
         )
       }


### PR DESCRIPTION
## Summary

- Remove the `#else self = light` fallback branch from the `Color(light:dark:highContrastLight:highContrastDark:)` initializer
- Since the project targets iOS 26+ and macOS 26+ only, either UIKit or AppKit will always be available, making this fallback dead code

## Test plan

- [x] Build succeeds
- [x] Verified only iOS and macOS platforms are supported in Package.swift

Closes #76