### PR TITLE
fix(snapshots): resolve PreviewGallery module naming conflict for iOS

### DIFF
--- a/Apps/PreviewGallery/Project.swift
+++ b/Apps/PreviewGallery/Project.swift
@@ -7,7 +7,7 @@ let project = Project(
   settings: .ironUISettings(),
   targets: [
     .target(
-      name: "PreviewGallery",
+      name: "PreviewGalleryApp",
       destinations: [.iPhone, .iPad, .mac],
       product: .app,
       bundleId: "dev.ironui.previewgallery",
@@ -37,7 +37,7 @@ let project = Project(
       deploymentTargets: .multiplatform(iOS: "26.0", macOS: "26.0"),
       sources: ["Tests/**/*.swift"],
       dependencies: [
-        .target(name: "PreviewGallery"),
+        .target(name: "PreviewGalleryApp"),
         .external(name: "SnapshotTesting"),
       ],
     ),
@@ -46,7 +46,7 @@ let project = Project(
     .scheme(
       name: "PreviewGallery",
       shared: true,
-      buildAction: .buildAction(targets: [.target("PreviewGallery")]),
+      buildAction: .buildAction(targets: [.target("PreviewGalleryApp")]),
       testAction: .targets([
         .testableTarget(target: .target("PreviewGalleryTests"))
       ]),
@@ -55,7 +55,7 @@ let project = Project(
     .scheme(
       name: "PreviewGallery-RecordSnapshots",
       shared: true,
-      buildAction: .buildAction(targets: [.target("PreviewGallery")]),
+      buildAction: .buildAction(targets: [.target("PreviewGalleryApp")]),
       testAction: .targets(
         [.testableTarget(target: .target("PreviewGalleryTests"))],
         arguments: .arguments(

--- a/Apps/PreviewGallery/Sources/ContentView.swift
+++ b/Apps/PreviewGallery/Sources/ContentView.swift
@@ -1,4 +1,4 @@
-import PreviewGallery
+import struct PreviewGallery.PreviewGallery
 import SwiftUI
 
 struct ContentView: View {


### PR DESCRIPTION
## Summary

- Rename the PreviewGalleryApp target to avoid collision with the external PreviewGallery library from SnapshotPreviews
- The app target and external dependency shared the same name `PreviewGallery`, causing Swift to fail resolving the `PreviewGallery` type on iOS builds
- Use explicit import `import struct PreviewGallery.PreviewGallery` to disambiguate the type from the module

## Changes

- Rename app target from `PreviewGallery` to `PreviewGalleryApp` in `Apps/PreviewGallery/Project.swift`
- Update test target dependency reference
- Update scheme build action targets
- Fix import in `ContentView.swift`

## Test plan

- [x] iOS build succeeds: `xcodebuild build -scheme PreviewGallery -destination "platform=iOS Simulator,name=iPhone 17 Pro"`
- [x] iOS snapshot tests pass: `swift run ironui-cli snapshots -r --platform ios`
- [x] macOS snapshot tests pass: `swift run ironui-cli snapshots -r --platform macos`

🤖 Generated with [Claude Code](https://claude.com/claude-code)