### PR TITLE
fix: use correct IronTextStyle cases in demo app

### DIFF
--- a/Apps/IronUIDemo/Sources/ContentView.swift
+++ b/Apps/IronUIDemo/Sources/ContentView.swift
@@ -5,8 +5,8 @@ struct ContentView: View {
   var body: some View {
     NavigationStack {
       VStack(spacing: 16) {
-        IronText("IronUI Demo", style: .headline)
-        IronText("Component showcase coming soon", style: .body)
+        IronText("IronUI Demo", style: .headlineLarge)
+        IronText("Component showcase coming soon", style: .bodyMedium)
       }
       .navigationTitle("IronUI Demo")
     }


### PR DESCRIPTION
## Summary

- Fix compilation error in IronUIDemo by using correct `IronTextStyle` enum cases
- Replace non-existent `.headline` and `.body` with `.headlineLarge` and `.bodyMedium`

## Context

The demo app referenced `IronTextStyle.headline` and `IronTextStyle.body`, but these cases don't exist in the enum. The available styles follow a Large/Medium/Small pattern (e.g., `.headlineLarge`, `.bodyMedium`).

## Test plan

- [x] Build succeeds with `swift run ironui-cli build`
- [x] Pre-commit hooks pass (swift-format, linting)