### PR TITLE
feat(IronIcon): add .inherit color for parent style inheritance

### DIFF
--- a/Sources/IronPrimitives/Icon/IronIcon.swift
+++ b/Sources/IronPrimitives/Icon/IronIcon.swift
@@ -78,9 +78,14 @@ public struct IronIcon: View {
   // MARK: Public
 
   public var body: some View {
-    iconView
-      .foregroundStyle(foregroundColor)
-      .accessibilityHidden(true)
+    if color == .inherit {
+      iconView
+        .accessibilityHidden(true)
+    } else {
+      iconView
+        .foregroundStyle(foregroundColor)
+        .accessibilityHidden(true)
+    }
   }
 
   // MARK: Private
@@ -157,6 +162,7 @@ public struct IronIcon: View {
 
   private var foregroundColor: Color {
     switch color {
+    case .inherit: .clear // Never reached - handled separately in body
     case .primary: theme.colors.textPrimary
     case .secondary: theme.colors.textSecondary
     case .disabled: theme.colors.textDisabled
@@ -206,7 +212,9 @@ public enum IronIconSize: Sendable, CaseIterable {
 ///
 /// Use semantic colors to ensure icons remain visible and
 /// meaningful across light and dark modes.
-public enum IronIconColor: Sendable {
+public enum IronIconColor: Sendable, Equatable {
+  /// Inherit color from parent view's foreground style.
+  case inherit
   /// Primary icon color for main content.
   case primary
   /// Secondary icon color for supporting content.


### PR DESCRIPTION
## Summary

Add new `.inherit` case to `IronIconColor` that allows icons to inherit their foreground color from parent views via `.foregroundStyle()`.

## Changes

- Add `IronIconColor.inherit` case
- Make `IronIconColor` conform to `Equatable` (required for `== .inherit` check)
- Update body to conditionally skip internal foreground style when `.inherit`
- Handle `.inherit` in foregroundColor switch (returns `.clear` as unreachable fallback)

## Motivation

When `IronIcon` is used inside components like `IronChip` that need to control icon color dynamically (e.g., based on selection state), the icon's internal `.foregroundStyle()` prevented the parent's style from cascading through.

With `.inherit`, parent components can now control the icon's color:

```swift
// Icon inherits color from parent
IronIcon(systemName: "star", color: .inherit)
  .foregroundStyle(.red) // This now works!

// Used internally by IronChip for selection-reactive icons
leadingIcon = IronIcon(systemName: icon, size: size, color: .inherit)
```

## Test Plan

- [x] Build succeeds
- [ ] Verify icons with `.inherit` respond to parent `.foregroundStyle()`
- [ ] Verify existing icon colors continue to work

Closes #98