### PR TITLE
docs: add pre-release warning to README and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+IronUI is in active development and has not yet reached its first stable release. All changes are tracked here until we tag 1.0.0.
+
+### ⚠️ Pre-Release Notice
+
+This library is under active development. APIs may change between commits. We recommend pinning to a specific commit hash if you need stability before 1.0.
+
+### Added
+- Initial component library with 60+ SwiftUI components
+- Complete theming system with 6 token categories
+- Full accessibility support (VoiceOver, Dynamic Type, reduced motion)
+- iOS 26+ and macOS 26+ support with Liquid Glass aesthetic
+- Swift 6 strict concurrency compliance
+- Developer CLI for build, test, format, and documentation tasks

--- a/README.md
+++ b/README.md
@@ -7,9 +7,12 @@ A modern, playful SwiftUI component library for iOS 26+ and macOS 26+, inspired 
 [![macOS 26+](https://img.shields.io/badge/macOS-26+-blue.svg)](https://developer.apple.com/macos/)
 [![MIT License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
+> [!WARNING]
+> **Pre-Release Software** — IronUI has not yet had its first stable release. APIs may change without notice. Use at your own risk until we reach 1.0, at which point we can commit to stable, production-ready components.
+
 ## Features
 
-- **60+ Production-Ready Components** - Buttons, forms, data display, navigation, and more
+- **60+ Components** - Buttons, forms, data display, navigation, and more
 - **Liquid Glass Aesthetic** - Designed for iOS 26 and macOS 26's visual language
 - **Complete Theming System** - 6 token categories with automatic light/dark mode adaptation
 - **Full Accessibility** - VoiceOver, Dynamic Type, and reduced motion support
@@ -32,9 +35,11 @@ Or add it to your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/Iron-Ham/IronUI", from: "1.0.0")
+    .package(url: "https://github.com/Iron-Ham/IronUI", branch: "main")
 ]
 ```
+
+> **Note:** Until 1.0 is released, pin to `main` or a specific commit hash for stability.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

- Add prominent warning banner to README clarifying IronUI has not had a stable release
- Update SPM installation example to use `branch: "main"` instead of `from: "1.0.0"`
- Remove "Production-Ready" claim from the Features list
- Add pre-release notice and initial "Added" section to CHANGELOG

## Changes

**README.md:**
- Added `[!WARNING]` callout at the top explaining pre-release status
- Changed "60+ Production-Ready Components" → "60+ Components"
- Updated Package.swift example to reference `main` branch
- Added note recommending commit hash pinning for stability

**CHANGELOG.md:**
- Added context about active development status under Unreleased
- Added pre-release notice section
- Added initial "Added" section documenting current capabilities