### PR TITLE
Decompose AGENTS.md into distributed living document system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,54 @@
-# IronUI Shared Agent Instructions
+# IronUI — Agent Instructions
 
-These instructions apply to both Claude and Codex when working in this repo.
+> **This is a living document.** Agents are encouraged to update and extend these
+> instructions as they learn about the codebase. See
+> [Self-Improvement Protocol](#self-improvement-protocol).
+
+## Self-Improvement Protocol
+
+This repo uses a **distributed AGENTS.md system**. Instructions are decomposed
+across directories so agents receive context scoped to their working directory.
+
+### How It Works
+
+- Each directory may contain an `AGENTS.md` with context specific to that area.
+- `CLAUDE.md` is always a **symlink** to `AGENTS.md` — never a standalone file.
+- Agents inherit instructions from all ancestor `AGENTS.md` files automatically.
+
+### When to Create or Update
+
+Agents **should** create or update an `AGENTS.md` when they:
+
+- Discover a non-obvious pattern, convention, or gotcha in a directory.
+- Learn something from a bug fix that future agents should know.
+- Identify dependencies or constraints between files that aren't obvious.
+- Find that existing instructions are outdated or incomplete.
+- Complete significant work in a directory that lacks an `AGENTS.md`.
+
+### Pre-Commit Knowledge Capture
+
+**Before committing, agents must pause and reflect:**
+
+1. Did I uncover any non-obvious behavior, gotcha, or pattern during this work?
+2. Did I learn something about a module's internals that isn't documented?
+3. Did I fix a bug whose root cause would be useful for future agents to know?
+4. Did I discover a relationship between files/modules that isn't captured?
+
+If the answer to any of these is **yes**, update the relevant `AGENTS.md` (or create
+one) as part of the same commit. Treat knowledge capture as part of the deliverable,
+not an afterthought.
+
+### Rules for Writing AGENTS.md
+
+- Keep instructions **scoped** to the directory — don't repeat ancestor content.
+- Be **concise** — bullet points over prose.
+- Include **concrete examples** where they clarify.
+- Date new entries: `<!-- Updated: YYYY-MM-DD -->`.
+- Always create the symlink alongside: `ln -s AGENTS.md CLAUDE.md`.
+- Never contradict ancestor instructions without explicit justification.
+- Prefer **learnings and gotchas** over restating obvious things.
+
+---
 
 ## Product Goals
 
@@ -19,33 +67,9 @@ These instructions apply to both Claude and Codex when working in this repo.
 ## Architecture & Modules
 
 - Follow the ADR-defined module hierarchy in `adrs/`.
-- Keep dependency direction one-way (Core → Primitives → Components → higher layers).
+- Keep dependency direction one-way: **Core → Primitives → Components → higher layers**.
 - Document significant architectural changes with a new ADR in `adrs/`.
-
-## Theming & Visual Identity
-
-- Use token-based theming (`IronTheme` and token protocols).
-- Default theme should embody the visual identity principles in `adrs/0003-visual-identity.md`
-  and `adrs/VISUAL_IDENTITY.md`.
-- Prefer semantic tokens; avoid hard-coded colors, spacing, or fonts in components.
-
-## Accessibility (Non-Negotiable)
-
-- Minimum touch targets: 44x44 points.
-- Meaningful labels/hints/values for all interactive elements.
-- Respect Dynamic Type and `accessibilityReduceMotion`.
-- Ensure WCAG AA contrast for default themes.
-
-## Prefer IronUI Primitives
-
-Use IronUI primitives instead of raw SwiftUI controls inside IronUI components:
-`IronText`, `IronIcon`, `IronButton`, `IronTextField`, `IronToggle`, etc.
-Exceptions: preview-only code for brevity.
-
-## Previews
-
-- Use `@Previewable` for state in previews.
-- Name previews descriptively (e.g., `"IronButton - Variants"`).
+- See `Sources/AGENTS.md` for coding conventions and module-specific context.
 
 ## Project Management: Tuist
 
@@ -87,7 +111,8 @@ For faster execution, use the cached wrapper script:
 ./Scripts/ironui-cli <command>
 ```
 
-The wrapper caches the compiled CLI binary and validates it against a checksum of the source files. This avoids recompilation on every invocation (~30-60s savings).
+The wrapper caches the compiled CLI binary and validates it against a checksum of the
+source files. This avoids recompilation on every invocation (~30-60s savings).
 
 Alternatively, `swift run ironui-cli <command>` works but recompiles the CLI each time.
 
@@ -100,31 +125,6 @@ Alternatively, `swift run ironui-cli <command>` works but recompiles the CLI eac
 | `format` | Format Swift sources (`--dry-run` to check only) |
 | `snapshots` | Run snapshot tests (`--platform`, `--record`, `--spm`) |
 | `test` | Run unit tests (`--platform macos/ios`, `--spm` for SPM mode) |
-
-## Testing
-
-- Unit tests: Swift Testing (not XCTestCase).
-- Snapshot tests: PointFree `swift-snapshot-testing`.
-- Add/maintain accessibility audits for interactive components.
-- Use `swift run ironui-cli test` for running tests.
-- Use `swift run ironui-cli snapshots` for snapshot tests (runs both macOS and iOS by default).
-- Use `swift run ironui-cli snapshots --record` to update snapshot baselines.
-- For snapshot/visual changes, always re-record snapshots for both iOS and macOS
-  and visually inspect the results.
-
-## Documentation
-
-- All public APIs must have DocC docs.
-- Update module DocC when public APIs change.
-- Prefer tutorials/articles for onboarding and complex components.
-- Use `swift run ironui-cli docs` for site generation.
-- Use `swift run ironui-cli docs --preview` to preview locally.
-- Use `swift run ironui-cli export-snapshots` to copy snapshots to DocC Resources.
-
-## Logging
-
-- Never use `print`, `debugPrint`, or `dump` in production code.
-- Use `IronLogger` from `IronCore` with appropriate log levels.
 
 ## Planning & Issues
 

--- a/Apps/AGENTS.md
+++ b/Apps/AGENTS.md
@@ -1,0 +1,11 @@
+# Apps — Agent Instructions
+
+<!-- Updated: 2026-02-18 -->
+
+> Companion apps for development, testing, and demo purposes.
+
+## Contents
+
+- **IronUIDemo/** — Main demo app showcasing all IronUI components.
+- **PreviewGallery/** — Visual gallery for browsing component previews.
+- **Housekeepr/** — Standalone app built with IronUI.

--- a/Apps/CLAUDE.md
+++ b/Apps/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Scripts/AGENTS.md
+++ b/Scripts/AGENTS.md
@@ -1,0 +1,11 @@
+# Scripts — Agent Instructions
+
+<!-- Updated: 2026-02-18 -->
+
+## Contents
+
+- **`ironui-cli`** — Cached wrapper around `swift run ironui-cli`. Compiles the CLI
+  binary once and caches it, validating against a checksum of the source files.
+  Use this instead of `swift run ironui-cli` for faster execution (~30-60s savings).
+- **`pre-commit`** — Git hook that formats Swift code on commit.
+  Install with: `ln -sf ../../Scripts/pre-commit .git/hooks/pre-commit`.

--- a/Scripts/CLAUDE.md
+++ b/Scripts/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Sources/AGENTS.md
+++ b/Sources/AGENTS.md
@@ -1,0 +1,57 @@
+# Sources — Agent Instructions
+
+<!-- Updated: 2026-02-18 -->
+
+> Coding conventions and shared guidance for all IronUI source modules.
+> Module-specific context lives in each module's own `AGENTS.md`.
+
+## Theming & Visual Identity
+
+- Use token-based theming (`IronTheme` and token protocols).
+- Default theme should embody the visual identity principles in `adrs/0003-visual-identity.md`
+  and `adrs/VISUAL_IDENTITY.md`.
+- Prefer semantic tokens; avoid hard-coded colors, spacing, or fonts in components.
+
+## Accessibility (Non-Negotiable)
+
+- Minimum touch targets: 44×44 points.
+- Meaningful labels/hints/values for all interactive elements.
+- Respect Dynamic Type and `accessibilityReduceMotion`.
+- Ensure WCAG AA contrast for default themes.
+
+## Prefer IronUI Primitives
+
+Use IronUI primitives instead of raw SwiftUI controls inside IronUI components:
+`IronText`, `IronIcon`, `IronButton`, `IronTextField`, `IronToggle`, etc.
+Exceptions: preview-only code for brevity.
+
+## Previews
+
+- Use `@Previewable` for state in previews.
+- Name previews descriptively (e.g., `"IronButton - Variants"`).
+
+## Documentation
+
+- All public APIs must have DocC docs.
+- Update module DocC when public APIs change.
+- Prefer tutorials/articles for onboarding and complex components.
+
+## Logging
+
+- Never use `print`, `debugPrint`, or `dump` in production code.
+- Use `IronLogger` from `IronCore` with appropriate log levels.
+
+## Module Dependency Order
+
+```
+IronCore (foundation — no IronUI dependencies)
+  └─► IronPrimitives (basic controls)
+        └─► IronComponents (composed controls)
+        └─► IronForms (form-specific components)
+        └─► IronLayouts (layout containers)
+        └─► IronNavigation (navigation patterns)
+        └─► IronDataDisplay (data visualization)
+              └─► IronUI (umbrella re-export)
+```
+
+Never import a higher-layer module from a lower-layer module.

--- a/Sources/CLAUDE.md
+++ b/Sources/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Sources/IronComponents/AGENTS.md
+++ b/Sources/IronComponents/AGENTS.md
@@ -1,0 +1,16 @@
+# IronComponents — Agent Instructions
+
+<!-- Updated: 2026-02-18 -->
+
+> Composed components built from IronPrimitives.
+
+## What Lives Here
+
+Avatar, Chip, Menu, SegmentedControl, Skeleton.
+
+## Key Conventions
+
+- Components compose primitives — prefer `IronText`, `IronButton`, etc. over raw SwiftUI.
+- Depends on `IronCore` and `IronPrimitives`.
+- Each component gets its own subdirectory.
+- Snapshot tests live in `Tests/IronUISnapshotTests/Components/`.

--- a/Sources/IronComponents/CLAUDE.md
+++ b/Sources/IronComponents/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Sources/IronCore/AGENTS.md
+++ b/Sources/IronCore/AGENTS.md
@@ -1,0 +1,20 @@
+# IronCore — Agent Instructions
+
+<!-- Updated: 2026-02-18 -->
+
+> Foundation module. Everything else depends on this — changes here ripple everywhere.
+
+## What Lives Here
+
+- **Animation/** — shared animation utilities and motion tokens.
+- **Environment/** — SwiftUI environment keys and values for theming/config.
+- **Interactions/** — gesture and interaction primitives.
+- **Layout/** — foundational layout utilities.
+- **Logging/** — `IronLogger` (the only approved logging mechanism).
+- **Theming/** — `IronTheme`, token protocols, and default theme definitions.
+
+## Key Constraints
+
+- This module has **zero IronUI dependencies** — it only imports SwiftUI/Foundation.
+- Any public API change here affects every downstream module. Be deliberate.
+- Theme token protocols defined here are the contract all components build against.

--- a/Sources/IronCore/CLAUDE.md
+++ b/Sources/IronCore/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Sources/IronDataDisplay/AGENTS.md
+++ b/Sources/IronDataDisplay/AGENTS.md
@@ -1,0 +1,15 @@
+# IronDataDisplay — Agent Instructions
+
+<!-- Updated: 2026-02-18 -->
+
+> Components for displaying structured data: tables, kanban boards, timelines.
+
+## What Lives Here
+
+Database, Kanban, Timeline.
+
+## Key Conventions
+
+- Depends on `IronCore` and `IronPrimitives`.
+- These components tend to be complex — pay extra attention to performance.
+- Snapshot tests live in `Tests/IronUISnapshotTests/DataDisplay/`.

--- a/Sources/IronDataDisplay/CLAUDE.md
+++ b/Sources/IronDataDisplay/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Sources/IronForms/AGENTS.md
+++ b/Sources/IronForms/AGENTS.md
@@ -1,0 +1,15 @@
+# IronForms — Agent Instructions
+
+<!-- Updated: 2026-02-18 -->
+
+> Form-related components: fields, validation, and layout.
+
+## What Lives Here
+
+DatePicker, Form, FormField, Validation.
+
+## Key Conventions
+
+- Depends on `IronCore` and `IronPrimitives`.
+- Form fields should integrate with the `Validation/` system.
+- Snapshot tests live in `Tests/IronUISnapshotTests/Forms/`.

--- a/Sources/IronForms/CLAUDE.md
+++ b/Sources/IronForms/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Sources/IronLayouts/AGENTS.md
+++ b/Sources/IronLayouts/AGENTS.md
@@ -1,0 +1,15 @@
+# IronLayouts — Agent Instructions
+
+<!-- Updated: 2026-02-18 -->
+
+> Layout containers: flow layouts, responsive grids, and spacing.
+
+## What Lives Here
+
+Container, Flow, Responsive.
+
+## Key Conventions
+
+- Depends on `IronCore`.
+- Layout components should respect theme spacing tokens.
+- Snapshot tests live in `Tests/IronUISnapshotTests/Layouts/`.

--- a/Sources/IronLayouts/CLAUDE.md
+++ b/Sources/IronLayouts/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Sources/IronNavigation/AGENTS.md
+++ b/Sources/IronNavigation/AGENTS.md
@@ -1,0 +1,20 @@
+# IronNavigation — Agent Instructions
+
+<!-- Updated: 2026-02-18 -->
+
+> Navigation patterns: trays, sheets, and navigation flows.
+
+## What Lives Here
+
+Tray.
+
+## Key Conventions
+
+- Depends on `IronCore`.
+- Snapshot tests live in `Tests/IronUISnapshotTests/Navigation/`.
+
+## Learnings
+
+<!-- Updated: 2026-02-18 -->
+- Column resize gestures on iOS can conflict with the system navigation back swipe.
+  See commit `ed6d4d83` for the fix pattern (prevent gesture interference).

--- a/Sources/IronNavigation/CLAUDE.md
+++ b/Sources/IronNavigation/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Sources/IronPrimitives/AGENTS.md
+++ b/Sources/IronPrimitives/AGENTS.md
@@ -1,0 +1,19 @@
+# IronPrimitives — Agent Instructions
+
+<!-- Updated: 2026-02-18 -->
+
+> Basic UI controls that wrap or replace SwiftUI built-ins.
+> Higher-layer modules should use these instead of raw SwiftUI views.
+
+## What Lives Here
+
+Alert, Badge, Button, Card, Checkbox, ContextLine, Divider, Icon, Progress,
+Radio, SecureField, Spinner, Text, TextField, Toggle.
+
+## Key Conventions
+
+- Each primitive lives in its own subdirectory (e.g., `Button/`).
+- Primitives depend only on `IronCore` — never on Components, Forms, etc.
+- All primitives must consume theme tokens, not hard-coded values.
+- Every interactive primitive needs accessibility labels, hints, and traits.
+- Snapshot tests for primitives live in `Tests/IronUISnapshotTests/Primitives/`.

--- a/Sources/IronPrimitives/CLAUDE.md
+++ b/Sources/IronPrimitives/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Tests/AGENTS.md
+++ b/Tests/AGENTS.md
@@ -1,0 +1,33 @@
+# Tests — Agent Instructions
+
+<!-- Updated: 2026-02-18 -->
+
+> Testing conventions for IronUI.
+
+## Frameworks
+
+- **Unit tests:** Swift Testing (`import Testing`, not XCTestCase).
+- **Snapshot tests:** PointFree `swift-snapshot-testing`.
+
+## Running Tests
+
+| Command | Purpose |
+|---------|---------|
+| `swift run ironui-cli test` | Run unit tests (both platforms) |
+| `swift run ironui-cli test --platform macos` | macOS only |
+| `swift run ironui-cli snapshots` | Run snapshot tests (both platforms) |
+| `swift run ironui-cli snapshots --record` | Update snapshot baselines |
+
+## Structure
+
+- Unit tests mirror the source module structure: `IronCoreTests/`, `IronPrimitivesTests/`, etc.
+- Snapshot tests are centralized in `IronUISnapshotTests/` with subdirectories per module.
+- `__Snapshots__/` directories contain recorded baselines — commit these.
+- `SnapshotTestUtilities.swift` has shared helpers for snapshot configuration.
+
+## Conventions
+
+- Add accessibility audits for interactive components.
+- For snapshot/visual changes, always re-record for **both iOS and macOS**.
+- Visually inspect snapshot diffs before committing.
+- Integration tests go in `IronUIIntegrationTests/`.

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/adrs/AGENTS.md
+++ b/adrs/AGENTS.md
@@ -1,0 +1,25 @@
+# ADRs — Agent Instructions
+
+<!-- Updated: 2026-02-18 -->
+
+> Architecture Decision Records for IronUI.
+
+## When to Write an ADR
+
+- Any significant architectural change (new module, dependency change, API redesign).
+- Use `0000-template.md` as the starting point.
+- Number sequentially: the next ADR is `0008-*.md`.
+
+## Existing ADRs
+
+| ADR | Topic |
+|-----|-------|
+| 0001 | Module structure |
+| 0002 | Theming approach |
+| 0003 | Visual identity |
+| 0004 | Accessibility strategy |
+| 0005 | Testing strategy |
+| 0006 | Component API design |
+| 0007 | Tuist migration |
+
+`VISUAL_IDENTITY.md` is a standalone design reference (not an ADR).

--- a/adrs/CLAUDE.md
+++ b/adrs/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary

- Restructures agent instructions from a single root `AGENTS.md` into a directory-scoped system where each module has its own `AGENTS.md` with locally relevant context
- Adds a **Self-Improvement Protocol** that encourages agents to capture learnings in the nearest `AGENTS.md` as they work
- Adds a **Pre-Commit Knowledge Capture** checklist — agents reflect on what they learned before every commit
- Creates scoped `AGENTS.md` files for `Sources/`, each source module, `Tests/`, `adrs/`, `Scripts/`, and `Apps/`
- All `CLAUDE.md` files are symlinks to `AGENTS.md`

## Test plan

- [x] Verify all `CLAUDE.md` files are symlinks to `AGENTS.md`
- [x] Verify root `AGENTS.md` contains the self-improvement protocol and pre-commit reflection
- [x] Verify each directory-level `AGENTS.md` is scoped to its directory without repeating root content