### PR TITLE
Add missing StringProtocol overloads and localize accessibility strings in IronChip

### DIFF
--- a/Sources/IronComponents/AGENTS.md
+++ b/Sources/IronComponents/AGENTS.md
@@ -14,3 +14,16 @@ Avatar, Chip, Menu, SegmentedControl, Skeleton.
 - Depends on `IronCore` and `IronPrimitives`.
 - Each component gets its own subdirectory.
 - Snapshot tests live in `Tests/IronUISnapshotTests/Components/`.
+
+## StringProtocol Overload Parity
+
+<!-- Updated: 2026-02-18 -->
+
+Every public initializer that takes `LocalizedStringKey` for a title **must** have a
+corresponding `some StringProtocol` overload. This is the standard SwiftUI pattern
+(see `SwiftUI.Text`). Without it, callers passing `String` variables get a compile
+error because Swift won't implicitly convert `String` → `LocalizedStringKey`.
+
+- When adding a new `LocalizedStringKey` init, always add the `StringProtocol` twin.
+- The `StringProtocol` overload converts via `LocalizedStringKey(String(title))`.
+- Use accessibility strings via `String(localized:)`, not bare string literals.

--- a/Sources/IronComponents/Chip/IronChip.swift
+++ b/Sources/IronComponents/Chip/IronChip.swift
@@ -105,6 +105,29 @@ public struct IronChip<LeadingIcon: View>: View {
     _isSelected = .constant(nil)
   }
 
+  /// Creates a chip with a system icon from a string.
+  ///
+  /// - Parameters:
+  ///   - title: The chip label string.
+  ///   - icon: The SF Symbol name.
+  ///   - variant: The visual style of the chip.
+  ///   - size: The size of the chip.
+  ///   - onDismiss: Optional dismiss action.
+  public init(
+    _ title: some StringProtocol,
+    icon: String,
+    variant: IronChipVariant = .filled,
+    size: IronChipSize = .medium,
+    onDismiss: (() -> Void)? = nil,
+  ) where LeadingIcon == IronIcon {
+    self.title = LocalizedStringKey(String(title))
+    self.variant = variant
+    self.size = size
+    self.onDismiss = onDismiss
+    leadingIcon = IronIcon(systemName: icon, size: Self.iconSize(for: size), color: .inherit)
+    _isSelected = .constant(nil)
+  }
+
   /// Creates a chip with a custom leading icon.
   ///
   /// - Parameters:
@@ -121,6 +144,29 @@ public struct IronChip<LeadingIcon: View>: View {
     @ViewBuilder leadingIcon: () -> LeadingIcon,
   ) {
     self.title = title
+    self.variant = variant
+    self.size = size
+    self.onDismiss = onDismiss
+    self.leadingIcon = leadingIcon()
+    _isSelected = .constant(nil)
+  }
+
+  /// Creates a chip with a custom leading icon from a string.
+  ///
+  /// - Parameters:
+  ///   - title: The chip label string.
+  ///   - variant: The visual style of the chip.
+  ///   - size: The size of the chip.
+  ///   - onDismiss: Optional dismiss action.
+  ///   - leadingIcon: The custom leading icon view.
+  public init(
+    _ title: some StringProtocol,
+    variant: IronChipVariant = .filled,
+    size: IronChipSize = .medium,
+    onDismiss: (() -> Void)? = nil,
+    @ViewBuilder leadingIcon: () -> LeadingIcon,
+  ) {
+    self.title = LocalizedStringKey(String(title))
     self.variant = variant
     self.size = size
     self.onDismiss = onDismiss
@@ -168,6 +214,78 @@ public struct IronChip<LeadingIcon: View>: View {
     self.size = size
     onDismiss = nil
     leadingIcon = IronIcon(systemName: icon, size: Self.iconSize(for: size), color: .inherit)
+    _isSelected = Binding(
+      get: { isSelected.wrappedValue },
+      set: { isSelected.wrappedValue = $0 ?? false },
+    )
+  }
+
+  /// Creates a selectable chip with a custom leading icon.
+  ///
+  /// - Parameters:
+  ///   - title: The chip label.
+  ///   - isSelected: Binding to the selection state.
+  ///   - size: The size of the chip.
+  ///   - leadingIcon: The custom leading icon view.
+  public init(
+    _ title: LocalizedStringKey,
+    isSelected: Binding<Bool>,
+    size: IronChipSize = .medium,
+    @ViewBuilder leadingIcon: () -> LeadingIcon,
+  ) {
+    self.title = title
+    variant = .outlined
+    self.size = size
+    onDismiss = nil
+    self.leadingIcon = leadingIcon()
+    _isSelected = Binding(
+      get: { isSelected.wrappedValue },
+      set: { isSelected.wrappedValue = $0 ?? false },
+    )
+  }
+
+  /// Creates a selectable chip with a system icon from a string.
+  ///
+  /// - Parameters:
+  ///   - title: The chip label string.
+  ///   - icon: The SF Symbol name.
+  ///   - isSelected: Binding to the selection state.
+  ///   - size: The size of the chip.
+  public init(
+    _ title: some StringProtocol,
+    icon: String,
+    isSelected: Binding<Bool>,
+    size: IronChipSize = .medium,
+  ) where LeadingIcon == IronIcon {
+    self.title = LocalizedStringKey(String(title))
+    variant = .outlined
+    self.size = size
+    onDismiss = nil
+    leadingIcon = IronIcon(systemName: icon, size: Self.iconSize(for: size), color: .inherit)
+    _isSelected = Binding(
+      get: { isSelected.wrappedValue },
+      set: { isSelected.wrappedValue = $0 ?? false },
+    )
+  }
+
+  /// Creates a selectable chip with a custom leading icon from a string.
+  ///
+  /// - Parameters:
+  ///   - title: The chip label string.
+  ///   - isSelected: Binding to the selection state.
+  ///   - size: The size of the chip.
+  ///   - leadingIcon: The custom leading icon view.
+  public init(
+    _ title: some StringProtocol,
+    isSelected: Binding<Bool>,
+    size: IronChipSize = .medium,
+    @ViewBuilder leadingIcon: () -> LeadingIcon,
+  ) {
+    self.title = LocalizedStringKey(String(title))
+    variant = .outlined
+    self.size = size
+    onDismiss = nil
+    self.leadingIcon = leadingIcon()
     _isSelected = Binding(
       get: { isSelected.wrappedValue },
       set: { isSelected.wrappedValue = $0 ?? false },

--- a/Tests/IronComponentsTests/IronComponentsTests.swift
+++ b/Tests/IronComponentsTests/IronComponentsTests.swift
@@ -238,6 +238,38 @@ struct IronChipTests {
     // Chip created successfully
   }
 
+  @Test("can be created with string variable and icon")
+  func createWithStringVariableAndIcon() {
+    let label: String = "Location"
+    _ = IronChip(label, icon: "mappin")
+    // Chip created successfully with StringProtocol + icon overload
+  }
+
+  @Test("can be created with string variable and custom leading icon")
+  func createWithStringVariableAndCustomIcon() {
+    let label: String = "Custom"
+    _ = IronChip(label) {
+      Image(systemName: "star.fill")
+    }
+    // Chip created successfully with StringProtocol + custom leading icon overload
+  }
+
+  @Test("can be created as selectable with string variable and icon")
+  func createAsSelectableWithStringVariableAndIcon() {
+    let label: String = "Filter"
+    _ = IronChip(label, icon: "line.3.horizontal.decrease", isSelected: .constant(false))
+    // Chip created successfully with StringProtocol + selectable icon overload
+  }
+
+  @Test("can be created as selectable with string variable and custom leading icon")
+  func createAsSelectableWithStringVariableAndCustomIcon() {
+    let label: String = "Custom"
+    _ = IronChip(label, isSelected: .constant(true), leadingIcon: {
+      Image(systemName: "star.fill")
+    })
+    // Chip created successfully with StringProtocol + selectable custom leading icon overload
+  }
+
   @Test("supports all variants", arguments: IronChipVariant.allCases)
   func supportsVariant(variant: IronChipVariant) {
     _ = IronChip("Test", variant: variant)


### PR DESCRIPTION
## Summary

- Adds `StringProtocol` overloads for all `IronChip` initializers that only accepted `LocalizedStringKey` — completing full parity (7 `LocalizedStringKey` : 7 `StringProtocol`)
- Localizes hardcoded English accessibility strings (`"Remove"`, `"Selected"`, `"Not selected"`, `"Removable"`) using `String(localized:)` for VoiceOver i18n support
- Aligns the accessibility dismiss action with the visual dismiss button (adds animation + logging)
- Adds new `LocalizedStringKey` + `StringProtocol` initializer pair for selectable chips with custom `@ViewBuilder` leading icons
- Documents the `StringProtocol` overload parity convention in `Sources/IronComponents/AGENTS.md`

## Test plan

- [ ] CI passes (SPM build + unit tests)
- [ ] Verify `IronChip(someString, icon: "archivebox", variant: .outlined)` compiles without wrapping in `LocalizedStringKey()`
- [ ] Verify accessibility strings are localizable (check `.xcstrings` catalog picks them up)

Fixes #124